### PR TITLE
Improve BloomFilter efficiency

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/membership/BloomCalculations.java
+++ b/src/main/java/com/clearspring/analytics/stream/membership/BloomCalculations.java
@@ -18,8 +18,6 @@
 
 package com.clearspring.analytics.stream.membership;
 
-import java.util.Arrays;
-
 /**
  * The following calculations are taken from:
  * http://www.cs.wisc.edu/~cao/papers/summary-cache/node8.html


### PR DESCRIPTION
Applies the patch from [CASSANDRA-1220](https://issues.apache.org/jira/browse/CASSANDRA-1220):

> [T]he table of false positives for a given number of bits per element and a given number of hashes in BloomCalculations is incomplete. This patch includes the calculations from Table 5 of Bloom Filters - The Math, which is referenced in the documentation at the source of the table. This changes the optimal number of hashes for the Bloom filters created by SSTableWriter (with 15 bits per element) from 8 to 10, with a reduction in the false positive rate from 0.000852 to 0.000744. (The patch also extends the table to include false positive rates for 16-20 bits per element for future reference.)
