### PR TITLE
Dramatically faster MurmurHash for primitive types

### DIFF
--- a/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
+++ b/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
@@ -28,6 +28,23 @@ package com.clearspring.analytics.hash;
  */
 public class MurmurHash
 {
+    public static int hash(Object o)
+    {
+        if (o == null)
+            return 0;
+        if(o instanceof Long)
+            return hashLong((Long)o);
+        if(o instanceof Integer)
+            return hashLong((Integer)o);
+        if(o instanceof Double)
+            return hashLong(Double.doubleToRawLongBits((Double)o));
+        if(o instanceof Float)
+            return hashLong(Float.floatToRawIntBits((Float)o));
+        if(o instanceof String)
+            return hash(((String)o).getBytes());
+        return hash(o.toString());
+    }
+
     public static int hash(byte[] data)
     {
         return hash(data, data.length, -1);
@@ -85,6 +102,29 @@ public class MurmurHash
 
             h *= m;
         }
+
+        h ^= h >>> 13;
+        h *= m;
+        h ^= h >>> 15;
+
+        return h;
+    }
+
+    public static int hashLong(long data)
+    {
+        int m = 0x5bd1e995;
+        int r = 24;
+
+        int h = 0;
+
+        int k = (int)data * m;
+        k ^= k >>> r;
+        h ^= k*m;
+
+        k = (int)(data>>32) * m;
+        k ^= k >>> r;
+        h *= m;
+        h ^= k*m;
 
         h ^= h >>> 13;
         h *= m;

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
@@ -161,7 +161,7 @@ public class HyperLogLog implements ICardinality
     @Override
     public boolean offer(Object o)
     {
-        final int x = MurmurHash.hash(o.toString().getBytes());
+        final int x = MurmurHash.hash(o);
         // j becomes the binary address determined by the first b log2m of x
         // j will be between 0 and 2^log2m
         final int j = x >>> (Integer.SIZE - log2m);

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/LinearCounting.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/LinearCounting.java
@@ -16,10 +16,10 @@
 
 package com.clearspring.analytics.stream.cardinality;
 
-import java.io.Serializable;
-
-import com.clearspring.analytics.util.IBuilder;
 import com.clearspring.analytics.hash.MurmurHash;
+import com.clearspring.analytics.util.IBuilder;
+
+import java.io.Serializable;
 
 /**
  * See <i>A Linear-Time Probabilistic Counting Algorithm for Database Applications</i>
@@ -80,7 +80,7 @@ public class LinearCounting implements ICardinality
     {
         boolean modified = false;
 
-        long hash = (long)MurmurHash.hash(o.toString().getBytes());
+        long hash = (long)MurmurHash.hash(o);
         int bit = (int)((hash & 0xFFFFFFFFL) % (long)length);
         int i = bit/8;
         byte b = map[i];

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/LogLog.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/LogLog.java
@@ -118,7 +118,7 @@ public class LogLog implements ICardinality
     {
         boolean modified = false;
 
-        int x = MurmurHash.hash(o.toString().getBytes());
+        int x = MurmurHash.hash(o);
         int j = x >>> (Integer.SIZE - k);
         byte r = (byte)(Integer.numberOfLeadingZeros( (x << k) | (1<<(k-1)) )+1);
         if(M[j] < r)

--- a/src/test/java/com/clearspring/analytics/stream/cardinality/TestLinearCounting.java
+++ b/src/test/java/com/clearspring/analytics/stream/cardinality/TestLinearCounting.java
@@ -16,16 +16,13 @@
 
 package com.clearspring.analytics.stream.cardinality;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.clearspring.analytics.stream.cardinality.LinearCounting.Builder;
+import com.clearspring.analytics.stream.cardinality.LinearCounting.LinearCountingMergeException;
+import org.junit.Test;
 
 import java.util.Arrays;
 
-import org.junit.Test;
-
-import com.clearspring.analytics.stream.cardinality.LinearCounting.Builder;
-import com.clearspring.analytics.stream.cardinality.LinearCounting.LinearCountingMergeException;
+import static org.junit.Assert.*;
 
 public class TestLinearCounting 
 {
@@ -41,7 +38,7 @@ public class TestLinearCounting
         lc.offer(17);
         lc.offer(18);
         lc.offer(19);
-        assertEquals(24, lc.computeCount());
+        assertEquals(27, lc.computeCount());
     }
     
     @Test


### PR DESCRIPTION
TestHyperLogLog down from 100+s to 8.5s which are mostly random number generation

(Chris, I'm also working right now on finally bringing my "cleanup" branch into order, but I ran tests just to check my code worked, and they took 100+ seconds, so I just had to fix this first).
