### PR TITLE
Made HyperLogLog serializable, added population count

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>stream</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.6

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <version>7</version>
   </parent>
 
-  <groupId>com.clearspring.analytics</groupId>
+  <groupId>com.centrifuge</groupId>
   <artifactId>stream</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.1</version>
   <name>stream-lib</name>
   <description>A library for summarizing data in streams for which it is infeasible to store all events</description>
   <url>https://github.com/clearspring/stream-lib</url>
@@ -147,21 +147,7 @@
           <stagingRepository>sonatype-nexus-staging::default::https://oss.sonatype.org/service/local/staging/deploy/maven2</stagingRepository>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.0</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+      
     </plugins>        
   </build>
 

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/RegisterSet.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/RegisterSet.java
@@ -16,9 +16,17 @@
 
 package com.clearspring.analytics.stream.cardinality;
 
-public class RegisterSet
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+public class RegisterSet implements Serializable
 {
-    public final static int LOG2_BITS_PER_WORD = 6;
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	public final static int LOG2_BITS_PER_WORD = 6;
     public final static int REGISTER_SIZE = 5;
 
     public final int count;


### PR DESCRIPTION
I'm using this in my app, and as part of that I needed to be able to serialize HyperLogLog to a cache. So I made all of the necessary classes implement Serializable.

Also in this commit I added a population count to the HyperLogLog class so that the number of items submitted can be tracked in the class itself. This is very helpful to my application as well.
