### PR TITLE
Enable ICardinality.offer to take a byte[]

### DIFF
--- a/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
+++ b/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
@@ -42,6 +42,8 @@ public class MurmurHash
             return hashLong(Float.floatToRawIntBits((Float)o));
         if(o instanceof String)
             return hash(((String)o).getBytes());
+        if(o instanceof byte[])
+            return hash((byte[])o);
         return hash(o.toString());
     }
 

--- a/src/test/java/com/clearspring/analytics/hash/TestMurmurHash.java
+++ b/src/test/java/com/clearspring/analytics/hash/TestMurmurHash.java
@@ -1,0 +1,40 @@
+package com.clearspring.analytics.hash;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+/**
+ * @author epollan
+ */
+public class TestMurmurHash {
+
+    @Test
+    public void testHashByteArrayOverload() {
+        String input = "hashthis";
+        byte[] inputBytes = input.getBytes();
+
+        int hashOfString = MurmurHash.hash(input);
+        Assert.assertEquals("MurmurHash.hash(byte[]) did not match MurmurHash.hash(String)",
+                            hashOfString, MurmurHash.hash(inputBytes));
+
+        Object bytesAsObject = inputBytes;
+        Assert.assertEquals("MurmurHash.hash(Object) given a byte[] did not match MurmurHash.hash(String)",
+                            hashOfString, MurmurHash.hash(bytesAsObject));
+    }
+}


### PR DESCRIPTION
We have need to offer pre-encoded byte[] from MapReduce process to a HyperLogLog estimator, but this didn't work due to the MurmurHash.hash(Object) not handling a byte[] properly (and delegating to MurmurHash.hash(byte[]).
