### PR TITLE
Support byte[] 64-bit MurmurHashing

### DIFF
--- a/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
+++ b/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
@@ -146,6 +146,11 @@ public class MurmurHash
 			final byte[] bytes = ((String)o).getBytes();
 			return hash64(bytes, bytes.length);
 		}
+        else if (o instanceof byte[])
+        {
+            final byte[] bytes = (byte[])o;
+            return hash64(bytes, bytes.length);
+        }
 		return hash64(o.toString());
 	}
 

--- a/src/test/java/com/clearspring/analytics/hash/TestMurmurHash.java
+++ b/src/test/java/com/clearspring/analytics/hash/TestMurmurHash.java
@@ -37,4 +37,18 @@ public class TestMurmurHash {
         Assert.assertEquals("MurmurHash.hash(Object) given a byte[] did not match MurmurHash.hash(String)",
                             hashOfString, MurmurHash.hash(bytesAsObject));
     }
+
+    @Test
+    public void testHash64ByteArrayOverload() {
+        String input = "hashthis";
+        byte[] inputBytes = input.getBytes();
+
+        long hashOfString = MurmurHash.hash64(input);
+        Assert.assertEquals("MurmurHash.hash64(byte[]) did not match MurmurHash.hash64(String)",
+                            hashOfString, MurmurHash.hash64(inputBytes));
+
+        Object bytesAsObject = inputBytes;
+        Assert.assertEquals("MurmurHash.hash64(Object) given a byte[] did not match MurmurHash.hash64(String)",
+                            hashOfString, MurmurHash.hash64(bytesAsObject));
+    }
 }


### PR DESCRIPTION
Cherry-picked the support for passing a byte[] to MurmurHash.hash(Object) out to the hll_plus_plus branch and added analogous capabilities to the 64-bit code path.

The diff looks a little funny b/c much of the 64-bit code paths seem to have been added with tab-based indention, rather than spaces.  I chose to offer a minimal pull w/out reformatting the surrounding code.  LMK if this is a problem.
