### PR TITLE
add ability to disable sparse representation

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -117,14 +117,14 @@ public class HyperLogLogPlus implements ICardinality
             {189083, 185696.913, 182348.774, 179035.946, 175762.762, 172526.444, 169329.754, 166166.099, 163043.269, 159958.91, 156907.912, 153906.845, 150924.199, 147996.568, 145093.457, 142239.233, 139421.475, 136632.27, 133889.588, 131174.2, 128511.619, 125868.621, 123265.385, 120721.061, 118181.769, 115709.456, 113252.446, 110840.198, 108465.099, 106126.164, 103823.469, 101556.618, 99308.004, 97124.508, 94937.803, 92833.731, 90745.061, 88677.627, 86617.47, 84650.442, 82697.833, 80769.132, 78879.629, 77014.432, 75215.626, 73384.587, 71652.482, 69895.93, 68209.301, 66553.669, 64921.981, 63310.323, 61742.115, 60205.018, 58698.658, 57190.657, 55760.865, 54331.169, 52908.167, 51550.273, 50225.254, 48922.421, 47614.533, 46362.049, 45098.569, 43926.083, 42736.03, 41593.473, 40425.26, 39316.237, 38243.651, 37170.617, 36114.609, 35084.19, 34117.233, 33206.509, 32231.505, 31318.728, 30403.404, 29540.0550000001, 28679.236, 27825.862, 26965.216, 26179.148, 25462.08, 24645.952, 23922.523, 23198.144, 22529.128, 21762.4179999999, 21134.779, 20459.117, 19840.818, 19187.04, 18636.3689999999, 17982.831, 17439.7389999999, 16874.547, 16358.2169999999, 15835.684, 15352.914, 14823.681, 14329.313, 13816.897, 13342.874, 12880.882, 12491.648, 12021.254, 11625.392, 11293.7610000001, 10813.697, 10456.209, 10099.074, 9755.39000000001, 9393.18500000006, 9047.57900000003, 8657.98499999999, 8395.85900000005, 8033, 7736.95900000003, 7430.59699999995, 7258.47699999996, 6924.58200000005, 6691.29399999999, 6357.92500000005, 6202.05700000003, 5921.19700000004, 5628.28399999999, 5404.96799999999, 5226.71100000001, 4990.75600000005, 4799.77399999998, 4622.93099999998, 4472.478, 4171.78700000001, 3957.46299999999, 3868.95200000005, 3691.14300000004, 3474.63100000005, 3341.67200000002, 3109.14000000001, 3071.97400000005, 2796.40399999998, 2756.17799999996, 2611.46999999997, 2471.93000000005, 2382.26399999997, 2209.22400000005, 2142.28399999999, 2013.96100000001, 1911.18999999994, 1818.27099999995, 1668.47900000005, 1519.65800000005, 1469.67599999998, 1367.13800000004, 1248.52899999998, 1181.23600000003, 1022.71900000004, 1088.20700000005, 959.03600000008, 876.095999999903, 791.183999999892, 703.337000000058, 731.949999999953, 586.86400000006, 526.024999999907, 323.004999999888, 320.448000000091, 340.672999999952, 309.638999999966, 216.601999999955, 102.922999999952, 19.2399999999907, -0.114000000059605, -32.6240000000689, -89.3179999999702, -153.497999999905, -64.2970000000205, -143.695999999996, -259.497999999905, -253.017999999924, -213.948000000091, -397.590000000084, -434.006000000052, -403.475000000093, -297.958000000101, -404.317000000039, -528.898999999976, -506.621000000043, -513.205000000075, -479.351000000024, -596.139999999898, -527.016999999993, -664.681000000099, -680.306000000099, -704.050000000047, -850.486000000034, -757.43200000003, -713.308999999892,}
     };
 
-    private Format format = Format.SPARSE;
+    private Format format;
     private final RegisterSet registerSet;
     private final int m;
     private final int p;
 
     //Sparse versions of m and p
-    private final int sm;
-    private final int sp;
+    private int sm;
+    private int sp;
 
     private final double alphaMM;
 
@@ -135,13 +135,13 @@ public class HyperLogLogPlus implements ICardinality
     private int prevMergedDelta = 0;
 
 
-    private final ArrayList<Integer> tmpSet = new ArrayList<Integer>(1000);
+    private ArrayList<Integer> tmpSet;
     private List<byte[]> sparseSet;
     //How big the sparse set is allowed to get before we convert to 'normal'
-    private final int sparseSetThreshold;
+    private int sparseSetThreshold;
 
     //How big the temp list is allowed to get before we batch merge it into the sparse set
-    static final int SORT_THRESHOLD = 50000;
+    private int sortThreshold;
 
 
     public HyperLogLogPlus(int p, int sp)
@@ -161,7 +161,7 @@ public class HyperLogLogPlus implements ICardinality
 
     public HyperLogLogPlus(int p, int sp, List<byte[]> sparseSet, RegisterSet registerSet)
     {
-        if (p < 4 || p > sp)
+        if (p < 4 || (p > sp && sp != 0))
         {
             throw new IllegalArgumentException("p must be between 4 and sp (inclusive)");
         }
@@ -171,12 +171,20 @@ public class HyperLogLogPlus implements ICardinality
         }
 
         this.p = p;
-        this.sp = sp;
-        this.m = (int) Math.pow(2, p);
-        this.sm = (int) Math.pow(2, sp);
+        m = (int) Math.pow(2, p);
         this.registerSet = registerSet;
-        this.sparseSet = sparseSet;
-        this.sparseSetThreshold = (int) (m * 0.75);
+        format = Format.NORMAL;
+        if (sp != 0) // Use sparse representation
+        {
+            format = Format.SPARSE;
+            this.sp = sp;
+            sm = (int) Math.pow(2, sp);
+            this.sparseSet = sparseSet;
+            sparseSetThreshold = (int) (m * 0.75);
+            sortThreshold = sparseSetThreshold / 4;
+            tmpSet = new ArrayList<Integer>(sortThreshold);
+        }
+
         // See the paper.
         switch (p)
         {
@@ -229,7 +237,7 @@ public class HyperLogLogPlus implements ICardinality
                 int k = encodeHash(x, p, sp);
                 //Put the encoded data into the temp set
                 boolean ret = tmpSet.add(k);
-                if (tmpSet.size() > SORT_THRESHOLD)
+                if (tmpSet.size() > sortThreshold)
                 {
                     mergeTempList();
                     if (sparseSet.size() > sparseSetThreshold)
@@ -267,7 +275,7 @@ public class HyperLogLogPlus implements ICardinality
             }
         }
         format = Format.NORMAL;
-        tmpSet.clear();
+        tmpSet = null;
         sparseSet = null;
     }
 


### PR DESCRIPTION
1. add ability to disable sparse representation
2. set sort threshold based on the sparse set threshold

I did some memory profiling with YourKit and the sparse representation is taking up a ton of space. For p=15,sp=20 I was seeing the NORMAL RegisterSet use 68kB but the sparse set List was using over a megabyte. I'll look into some ways to optimize it but I think it'll require using an array rather than a List, which makes things more complicated. Either way, I think it is useful to have an option for disabling the sparse representation because it has performance overhead that may be undesirable in some cases.
