### PR TITLE
Add IFrenquency.merge(IFrequency) 

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/frequency/FrequencyMergeException.java
+++ b/src/main/java/com/clearspring/analytics/stream/frequency/FrequencyMergeException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2011 Clearspring Technologies, Inc. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.stream.frequency;
+
+@SuppressWarnings("serial")
+public abstract class FrequencyMergeException extends Exception
+{
+    public FrequencyMergeException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/test/java/com/clearspring/analytics/stream/frequency/CountMinSketchTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/frequency/CountMinSketchTest.java
@@ -2,9 +2,14 @@ package com.clearspring.analytics.stream.frequency;
 
 import org.junit.Test;
 
-import java.util.Random;
+import com.clearspring.analytics.stream.frequency.CountMinSketch.CMSMergeException;
 
+import java.util.Random;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class CountMinSketchTest
 {
@@ -50,5 +55,59 @@ public class CountMinSketchTest
         }
         double pCorrect = 1 - 1.0 * numErrors / actualFreq.length;
         assertTrue("Confidence not reached: required " + confidence + ", reached " + pCorrect, pCorrect > confidence);
+    }
+
+    @Test
+    public void merge() throws CMSMergeException
+    {
+        int numToMerge = 5;
+        int cardinality = 1000000;
+
+        double epsOfTotalCount = 0.0001;
+        double confidence = 0.99;
+        int seed = 7364181;
+
+        int maxScale = 20;
+        Random r = new Random();
+        TreeSet<Integer> vals = new TreeSet<Integer>();
+
+        CountMinSketch baseline = new CountMinSketch(epsOfTotalCount, confidence, seed);
+        CountMinSketch[] sketchs = new CountMinSketch[numToMerge];
+        for (int i = 0; i < numToMerge; i++)
+        {
+            sketchs[i] = new CountMinSketch(epsOfTotalCount, confidence, seed);
+            for (int j = 0; j < cardinality; j++)
+            {
+                int scale    = r.nextInt(maxScale);
+                int val      = r.nextInt(1 << scale);
+                vals.add(val);
+                sketchs[i].add(val, 1);
+                baseline.add(val, 1);
+            }
+        }
+
+        CountMinSketch merged = CountMinSketch.merge(sketchs);
+
+        assertEquals(baseline.size(), merged.size());
+        assertEquals(baseline.getConfidence(), merged.getConfidence(), baseline.getConfidence() / 100);
+        assertEquals(baseline.getRelativeError(), merged.getRelativeError(), baseline.getRelativeError() / 100);
+        for (int val : vals)
+        {
+            assertEquals(baseline.estimateCount(val), merged.estimateCount(val));
+        }
+    }
+
+    @Test
+    public void testMergeEmpty() throws CMSMergeException
+    {
+        assertNull(CountMinSketch.merge());
+    }
+
+    @Test(expected = CMSMergeException.class)
+    public void testUncompatibleMerge() throws CMSMergeException
+    {
+        CountMinSketch cms1 = new CountMinSketch(1, 1, 0);
+        CountMinSketch cms2 = new CountMinSketch(0.1, 0.1, 0);
+        CountMinSketch.merge(cms1, cms2);
     }
 }


### PR DESCRIPTION
Unlike ICardinality, nor IFrenquency nor CountMinSketch currently define a merge function. According to [Approximating Data with the Count-Min Data Structure](http://dimacs.rutgers.edu/~graham/pubs/papers/cmsoft.pdf) 

> But more than this, one can build sketches of different subsets of the data (after agreeing on the same parameters w, d and set of hash functions to use), and these sketches can be combined to give the sketch of the union of the data. Sketch combination is straightforward: given sketch arrays of size w × d, they are combined by summing them up, entry-wise.

Is there a specific reason for this function to be absent ? Since I need this feature for one of my project, I will happily implement it and send a pull request if you think that it would be an useful addition. 
