### PR TITLE
Faster hll card

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
@@ -170,9 +170,14 @@ public class HyperLogLog implements ICardinality
     {
         double registerSum = 0;
         int count = registerSet.count;
+        double zeros = 0.0;
         for (int j = 0; j < registerSet.count; j++)
         {
-            registerSum += 1.0 / (1<<registerSet.get(j));
+            int val = registerSet.get(j);
+            registerSum += 1.0 / (1<<val);
+            if (val == 0) {
+                zeros++;
+            }
         }
 
         double estimate = alphaMM * (1 / registerSum);
@@ -180,14 +185,6 @@ public class HyperLogLog implements ICardinality
         if (estimate <= (5.0 / 2.0) * count)
         {
             // Small Range Estimate
-            double zeros = 0.0;
-            for (int z = 0; z < count; z++)
-            {
-                if (registerSet.get(z) == 0)
-                {
-                    zeros++;
-                }
-            }
             return Math.round(count * Math.log(count / zeros));
         }
         else

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -477,9 +477,14 @@ public class HyperLogLogPlus implements ICardinality
             case NORMAL:
                 double registerSum = 0;
                 int count = registerSet.count;
+                double zeros = 0;
                 for (int j = 0; j < registerSet.count; j++)
                 {
-                    registerSum += 1.0 / (1<<registerSet.get(j));
+                    int val = registerSet.get(j);
+                    registerSum += 1.0 / (1<<val);
+                    if (val == 0) {
+                        zeros++;
+                    }
                 }
 
                 double estimate = alphaMM * (1 / registerSum);
@@ -487,15 +492,6 @@ public class HyperLogLogPlus implements ICardinality
                 if (estimate <= (5 * m))
                 {
                     estimatePrime = estimate - getEstimateBias(estimate, p);
-                }
-                // Small Range Estimate
-                double zeros = 0.0;
-                for (int z = 0; z < count; z++)
-                {
-                    if (registerSet.get(z) == 0)
-                    {
-                        zeros++;
-                    }
                 }
                 double H;
                 if (zeros > 0)


### PR DESCRIPTION
According to my benchmarks the new implementation is  3 to 50 times faster depending on the set cardinality.

```
==> master.txt <==
Benchmark                                            Thr    Cnt  Sec         Mean   Mean error          Var    Units
b.g.t.HLLCardinalityBenchmark.hllCardinalityEmpty      1      3    5    15457.128       47.659       69.176  ops/sec
b.g.t.HLLCardinalityBenchmark.hllCardinalityLarge      1      3    5     1362.456        8.625        2.266  ops/sec
b.g.t.HLLCardinalityBenchmark.hllCardinalityMedium     1      3    5     1817.350        8.034        1.966  ops/sec
b.g.t.HLLCardinalityBenchmark.hllCardinalitySmall      1      3    5    13523.778       40.515       49.991  ops/sec

==> faster_hll_card.txt <==
Benchmark                                            Thr    Cnt  Sec         Mean   Mean error          Var    Units
b.g.t.HLLCardinalityBenchmark.hllCardinalityEmpty      1      3    5    48636.378      311.322     2951.758  ops/sec
b.g.t.HLLCardinalityBenchmark.hllCardinalityLarge      1      3    5    50545.389      621.955    11780.896  ops/sec
b.g.t.HLLCardinalityBenchmark.hllCardinalityMedium     1      3    5    50327.211      842.108    21597.134  ops/sec
b.g.t.HLLCardinalityBenchmark.hllCardinalitySmall      1      3    5    49598.833      345.749     3640.675  ops/sec

```

The cardinality method could be optimized further using the same approach than the one I have used for merge but I'm not sure it currently worth it. I have to profile real some world jobs before going further. 
