### PR TITLE
Fix java 6 regression introduced by 0fcb80561cd9a5b3e7032224a1efd8749ee21b0d

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/ScoredItem.java
+++ b/src/main/java/com/clearspring/analytics/stream/ScoredItem.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * @author Eric Vlaanderen
  */
-public class ScoredItem<T> implements Comparable<ScoredItem>
+public class ScoredItem<T> implements Comparable<ScoredItem<T>>
 {
 	private final AtomicLong error;
 	private final AtomicLong count;
@@ -73,9 +73,11 @@ public class ScoredItem<T> implements Comparable<ScoredItem>
 	}
 
 	@Override
-	public int compareTo(final ScoredItem o)
+	public int compareTo(final ScoredItem<T> o)
 	{
-		return Long.compare(o.count.get(), count.get());
+		long x = o.count.get();
+		long y = count.get();
+		return (x < y) ? -1 : ((x == y) ? 0 : 1);
 	}
 
 	public String toString()


### PR DESCRIPTION
I think we are still targeting Java 6. Long.compare(long, long) has been added in Java 7. 

What do you think about creating a  [Travis CI](http://travis-ci.org) job to check that the build is always green in Java 6/7/8 ? 
