### PR TITLE
Checked Exceptions in HyperLogLog Serialization

### DIFF
--- a/src/main/java/com/clearspring/analytics/util/Bits.java
+++ b/src/main/java/com/clearspring/analytics/util/Bits.java
@@ -16,22 +16,22 @@
 
 package com.clearspring.analytics.util;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class Bits
 {
 
-    public static int[] getBits(byte[] mBytes) throws IOException
+    public static int[] getBits(byte[] mBytes)
     {
         int bitSize = mBytes.length / 4;
         int[] bits = new int[bitSize];
-        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(mBytes));
+        ByteBuffer buffer = ByteBuffer.wrap(mBytes);
+        
         for (int i = 0; i < bitSize; i++)
         {
-            bits[i] = dis.readInt();
+            bits[i] = buffer.getInt();
         }
+        
         return bits;
     }
 


### PR DESCRIPTION
I don't think the serialization methods in HyperLogLog need to throw checked exceptions.  (They clutter up client code, make it more likely that someone swallows an exception, etc.)  Avoiding this by simply using the tools in ByteBuffer.
