### PR TITLE
Ported t-digest to stream-lib's environment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
       <version>14.0.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.mahout</groupId>
+      <artifactId>mahout-math</artifactId>
+      <version>0.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -122,7 +128,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <!-- Create self-contained exec artifact for command line tools -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/clearspring/analytics/stream/quantile/GroupTree.java
+++ b/src/main/java/com/clearspring/analytics/stream/quantile/GroupTree.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.stream.quantile;
+
+import com.clearspring.analytics.util.AbstractIterator;
+import com.clearspring.analytics.util.Preconditions;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+
+/**
+ * A tree containing TDigest.Group.  This adds to the normal NavigableSet the
+ * ability to sum up the size of elements to the left of a particular group.
+ */
+public class GroupTree implements Iterable<TDigest.Group> {
+    private int count;
+    private int size;
+    private int depth;
+    private TDigest.Group leaf;
+    private GroupTree left, right;
+
+    public GroupTree() {
+        count = size = depth = 0;
+        leaf = null;
+        left = right = null;
+    }
+
+    public GroupTree(TDigest.Group leaf) {
+        size = depth = 1;
+        this.leaf = leaf;
+        count = leaf.count();
+        left = right = null;
+    }
+
+    public GroupTree(GroupTree left, GroupTree right) {
+        this.left = left;
+        this.right = right;
+        count = left.count + right.count;
+        size = left.size + right.size;
+        rebalance();
+        leaf = this.right.first();
+    }
+
+    public void add(TDigest.Group group) {
+        if (size == 0) {
+            leaf = group;
+            depth = 1;
+            count = group.count();
+            size = 1;
+            return;
+        } else if (size == 1) {
+            int order = group.compareTo(leaf);
+            if (order < 0) {
+                left = new GroupTree(group);
+                right = new GroupTree(leaf);
+            } else if (order > 0) {
+                left = new GroupTree(leaf);
+                right = new GroupTree(group);
+                leaf = group;
+            }
+        } else if (group.compareTo(leaf) < 0) {
+            left.add(group);
+        } else {
+            right.add(group);
+        }
+        count += group.count();
+        size++;
+        depth = Math.max(left.depth, right.depth) + 1;
+
+        rebalance();
+    }
+
+    private void rebalance() {
+        int l = left.depth();
+        int r = right.depth();
+        if (l > r + 1) {
+            if (left.left.depth() > left.right.depth()) {
+                rotate(left.left.left, left.left.right, left.right, right);
+            } else {
+                rotate(left.left, left.right.left, left.right.right, right);
+            }
+        } else if (r > l + 1) {
+            if (right.left.depth() > right.right.depth()) {
+                rotate(left, right.left.left, right.left.right, right.right);
+            } else {
+                rotate(left, right.left, right.right.left, right.right.right);
+            }
+        } else {
+            depth = Math.max(left.depth(), right.depth()) + 1;
+        }
+    }
+
+    private void rotate(GroupTree a, GroupTree b, GroupTree c, GroupTree d) {
+        left = new GroupTree(a, b);
+        right = new GroupTree(c, d);
+        count = left.count + right.count;
+        size = left.size + right.size;
+        depth = Math.max(left.depth(), right.depth()) + 1;
+        leaf = right.first();
+    }
+
+    private int depth() {
+        return depth;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    /**
+     * @return the number of items strictly before the current element
+     */
+    public int headCount(TDigest.Group base) {
+        if (size == 0) {
+            return 0;
+        } else if (left == null) {
+            return leaf.compareTo(base) < 0 ? 1 : 0;
+        } else {
+            if (base.compareTo(leaf) < 0) {
+                return left.headCount(base);
+            } else {
+                return left.size + right.headCount(base);
+            }
+        }
+    }
+
+    /**
+     * @return the sum of the size() function for all elements strictly before the current element.
+     */
+    public int headSum(TDigest.Group base) {
+        if (size == 0) {
+            return 0;
+        } else if (left == null) {
+            return leaf.compareTo(base) < 0 ? count : 0;
+        } else {
+            if (base.compareTo(leaf) <= 0) {
+                return left.headSum(base);
+            } else {
+                return left.count + right.headSum(base);
+            }
+        }
+    }
+
+    /**
+     * @return the first Group in this set
+     */
+    public TDigest.Group first() {
+        Preconditions.checkState(size > 0, "No first element of empty set");
+        if (left == null) {
+            return leaf;
+        } else {
+            return left.first();
+        }
+    }
+
+    /**
+     * Iteratres through all groups in the tree.
+     */
+    public Iterator<TDigest.Group> iterator() {
+        return iterator(null);
+    }
+
+    /**
+     * Iterates through all of the Groups in this tree in ascending order of means
+     *
+     * @param start The place to start this subset.  Remember that Groups are ordered by mean *and* id.
+     * @return An iterator that goes through the groups in order of mean and id starting at or after the
+     *         specified Group.
+     */
+    private Iterator<TDigest.Group> iterator(final TDigest.Group start) {
+        return new AbstractIterator<TDigest.Group>() {
+            {
+                stack = new ArrayDeque<GroupTree>();
+                push(GroupTree.this, start);
+            }
+
+            Deque<GroupTree> stack;
+
+            // recurses down to the leaf that is >= start
+            // pending right hand branches on the way are put on the stack
+            private void push(GroupTree z, TDigest.Group start) {
+                while (z.left != null) {
+                    if (start == null || start.compareTo(z.leaf) < 0) {
+                        // remember we will have to process the right hand branch later
+                        stack.push(z.right);
+                        // note that there is no guarantee that z.left has any good data
+                        z = z.left;
+                    } else {
+                        // if the left hand branch doesn't contain start, then no push
+                        z = z.right;
+                    }
+                }
+                // put the leaf value on the stack if it is valid
+                if (start == null || z.leaf.compareTo(start) >= 0) {
+                    stack.push(z);
+                }
+            }
+
+            @Override
+            protected TDigest.Group computeNext() {
+                GroupTree r = stack.poll();
+                while (r != null && r.left != null) {
+                    // unpack r onto the stack
+                    push(r, start);
+                    r = stack.poll();
+                }
+
+                // at this point, r == null or r.left == null
+                // if r == null, stack is empty and we are done
+                // if r != null, then r.left != null and we have a result
+                if (r != null) {
+                    return r.leaf;
+                }
+                return endOfData();
+            }
+        };
+    }
+
+    public void remove(TDigest.Group base) {
+        Preconditions.checkState(size > 0, "Cannot remove from empty set");
+        if (size == 1) {
+            Preconditions.checkArgument(base.compareTo(leaf) == 0, "Element %s not found", base);
+            count = size = 0;
+            leaf = null;
+        } else {
+            if (base.compareTo(leaf) < 0) {
+                if (left.size > 1) {
+                    left.remove(base);
+                    count -= base.count();
+                    size--;
+                    rebalance();
+                } else {
+                    size = right.size;
+                    count = right.count;
+                    depth = right.depth;
+                    leaf = right.leaf;
+                    left = right.left;
+                    right = right.right;
+                }
+            } else {
+                if (right.size > 1) {
+                    right.remove(base);
+                    leaf = right.first();
+                    count -= base.count();
+                    size--;
+                    rebalance();
+                } else {
+                    size = left.size;
+                    count = left.count;
+                    depth = left.depth;
+                    leaf = left.leaf;
+                    right = left.right;
+                    left = left.left;
+                }
+            }
+        }
+    }
+
+    /**
+     * @return the largest element less than or equal to base
+     */
+    public TDigest.Group floor(TDigest.Group base) {
+        if (size == 0) {
+            return null;
+        } else {
+            if (size == 1) {
+                return base.compareTo(leaf) >= 0 ? leaf : null;
+            } else {
+                if (base.compareTo(leaf) < 0) {
+                    return left.floor(base);
+                } else {
+                    TDigest.Group floor = right.floor(base);
+                    if (floor == null) {
+                        floor = left.last();
+                    }
+                    return floor;
+                }
+            }
+        }
+    }
+
+    public TDigest.Group last() {
+        Preconditions.checkState(size > 0, "Cannot find last element of empty set");
+        if (size == 1) {
+            return leaf;
+        } else {
+            return right.last();
+        }
+    }
+
+    /**
+     * @return the smallest element greater than or equal to base.
+     */
+    public TDigest.Group ceiling(TDigest.Group base) {
+        if (size == 0) {
+            return null;
+        } else if (size == 1) {
+            return base.compareTo(leaf) <= 0 ? leaf : null;
+        } else {
+            if (base.compareTo(leaf) < 0) {
+                TDigest.Group r = left.ceiling(base);
+                if (r == null) {
+                    r = right.first();
+                }
+                return r;
+            } else {
+                return right.ceiling(base);
+            }
+        }
+    }
+
+    /**
+     * @return the subset of elements equal to or greater than base.
+     */
+    public Iterable<TDigest.Group> tailSet(final TDigest.Group start) {
+        return new Iterable<TDigest.Group>() {
+            @Override
+            public Iterator<TDigest.Group> iterator() {
+                return GroupTree.this.iterator(start);
+            }
+        };
+    }
+
+    public int sum() {
+        return count;
+    }
+
+    public void checkBalance() {
+        if (left != null) {
+            Preconditions.checkState(Math.abs(left.depth() - right.depth()) < 2, "Imbalanced");
+            int l = left.depth();
+            int r = right.depth();
+            Preconditions.checkState(depth == Math.max(l, r) + 1, "Depth doesn't match children");
+            Preconditions.checkState(size == left.size + right.size, "Sizes don't match children");
+            Preconditions.checkState(count == left.count + right.count, "Counts don't match children");
+            Preconditions.checkState(leaf.compareTo(right.first()) == 0, "Split is wrong %.5d != %.5d or %d != %d", leaf.mean(), right.first().mean(), leaf.id(), right.first().id());
+            left.checkBalance();
+            right.checkBalance();
+        }
+    }
+
+    public void print(int depth) {
+        for (int i = 0; i < depth; i++) {
+            System.out.printf("| ");
+        }
+        int imbalance = Math.abs((left != null ? left.depth : 1) - (right != null ? right.depth : 1));
+        System.out.printf("%s%s, %d, %d, %d\n", (imbalance > 1 ? "* " : "") + (right != null && leaf.compareTo(right.first()) != 0 ? "+ " : ""), leaf, size, count, this.depth);
+        if (left != null) {
+            left.print(depth + 1);
+            right.print(depth + 1);
+        }
+    }
+}

--- a/src/main/java/com/clearspring/analytics/stream/quantile/TDigest.java
+++ b/src/main/java/com/clearspring/analytics/stream/quantile/TDigest.java
@@ -1,0 +1,578 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.stream.quantile;
+
+import com.clearspring.analytics.util.Lists;
+import com.clearspring.analytics.util.Preconditions;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
+ * <p/>
+ * The special characteristics of this algorithm are:
+ * <p/>
+ * a) smaller summaries than Q-digest
+ * <p/>
+ * b) works on doubles as well as integers.
+ * <p/>
+ * c) provides part per million accuracy for extreme quantiles and typically <1000 ppm accuracy for middle quantiles
+ * <p/>
+ * d) fast
+ * <p/>
+ * e) simple
+ * <p/>
+ * f) test coverage > 90%
+ * <p/>
+ * g) easy to adapt for use with map-reduce
+ */
+public class TDigest {
+    private Random gen;
+
+    private double compression = 100;
+    private GroupTree summary = new GroupTree();
+    private int count = 0;
+    private boolean recordAllData = false;
+
+    /**
+     * A histogram structure that will record a sketch of a distribution.
+     *
+     * @param compression How should accuracy be traded for size?  A value of N here will give quantile errors
+     *                    almost always less than 3/N with considerably smaller errors expected for extreme
+     *                    quantiles.  Conversely, you should expect to track about 5 N centroids for this
+     *                    accuracy.
+     */
+    public TDigest(double compression) {
+        this(compression, new Random());
+    }
+
+    public TDigest(double compression, Random random) {
+        this.compression = compression;
+        gen = random;
+    }
+
+    /**
+     * Adds a sample to a histogram.
+     *
+     * @param x The value to add.
+     */
+    public void add(double x) {
+        add(x, 1);
+    }
+
+    /**
+     * Adds a sample to a histogram.
+     *
+     * @param x The value to add.
+     * @param w The weight of this point.
+     */
+    public void add(double x, int w) {
+        // note that because of a zero id, this will be sorted *before* any existing Group with the same mean
+        Group base = createGroup(x, 0);
+        add(x, w, base);
+    }
+
+    private void add(double x, int w, Group base) {
+        Group start = summary.floor(base);
+        if (start == null) {
+            start = summary.ceiling(base);
+        }
+
+        if (start == null) {
+            summary.add(Group.createWeighted(x, w, base.data()));
+            count = w;
+        } else {
+            Iterable<Group> neighbors = summary.tailSet(start);
+            double minDistance = Double.MAX_VALUE;
+            int lastNeighbor = 0;
+            int i = summary.headCount(start);
+            for (Group neighbor : neighbors) {
+                double z = Math.abs(neighbor.mean() - x);
+                if (z <= minDistance) {
+                    minDistance = z;
+                    lastNeighbor = i;
+                } else {
+                    break;
+                }
+                i++;
+            }
+
+            Group closest = null;
+            int sum = summary.headSum(start);
+            i = summary.headCount(start);
+            double n = 1;
+            for (Group neighbor : neighbors) {
+                if (i > lastNeighbor) {
+                    break;
+                }
+                double z = Math.abs(neighbor.mean() - x);
+                double q = (sum + neighbor.count() / 2.0) / count;
+                double k = 4 * count * q * (1 - q) / compression;
+
+                // this slightly clever selection method improves accuracy with lots of repeated points
+                if (z == minDistance && neighbor.count() + w <= k) {
+                    if (gen.nextDouble() < 1 / n) {
+                        closest = neighbor;
+                    }
+                    n++;
+                }
+                sum += neighbor.count();
+                i++;
+            }
+
+            if (closest == null) {
+                summary.add(Group.createWeighted(x, w, base.data()));
+            } else {
+                summary.remove(closest);
+                closest.add(x, w, base.data());
+                summary.add(closest);
+            }
+            count += w;
+
+            if (summary.size() > 100 * compression) {
+                // something such as sequential ordering of data points
+                // has caused a pathological expansion of our summary.
+                // To fight this, we simply replay the current centroids
+                // in random order.
+
+                // this causes us to forget the diagnostic recording of data points
+                compress();
+            }
+        }
+    }
+
+    public void add(TDigest other) {
+        List<Group> tmp = Lists.newArrayList(other.summary);
+
+        Collections.shuffle(tmp, gen);
+        for (Group group : tmp) {
+            add(group.mean(), group.count(), group);
+        }
+    }
+
+    public static TDigest merge(double compression, Iterable<TDigest> subData) {
+        Preconditions.checkArgument(subData.iterator().hasNext(), "Can't merge 0 digests");
+        List<TDigest> elements = Lists.newArrayList(subData);
+        int n = Math.max(1, elements.size() / 4);
+        TDigest r = new TDigest(compression, elements.get(0).gen);
+        if (elements.get(0).recordAllData) {
+            r.recordAllData();
+        }
+        for (int i = 0; i < elements.size(); i += n) {
+            if (n > 1) {
+                r.add(merge(compression, elements.subList(i, Math.min(i + n, elements.size()))));
+            } else {
+                r.add(elements.get(i));
+            }
+        }
+        return r;
+    }
+
+    public void compress() {
+        compress(summary);
+    }
+
+    private void compress(GroupTree other) {
+        TDigest reduced = new TDigest(compression, gen);
+        if (recordAllData) {
+            reduced.recordAllData();
+        }
+        List<Group> tmp = Lists.newArrayList(other);
+        Collections.shuffle(tmp, gen);
+        for (Group group : tmp) {
+            reduced.add(group.mean(), group.count(), group);
+        }
+
+        summary = reduced.summary;
+    }
+
+    /**
+     * Returns the number of samples represented in this histogram.  If you want to know how many
+     * centroids are being used, try centroids().size().
+     *
+     * @return the number of samples that have been added.
+     */
+    public int size() {
+        return count;
+    }
+
+    /**
+     * @param x the value at which the CDF should be evaluated
+     * @return the approximate fraction of all samples that were less than or equal to x.
+     */
+    public double cdf(double x) {
+        GroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return x < values.first().mean() ? 0 : 1;
+        } else {
+            double r = 0;
+
+            // we scan a across the centroids
+            Iterator<Group> it = values.iterator();
+            Group a = it.next();
+
+            // b is the look-ahead to the next centroid
+            Group b = it.next();
+
+            // initially, we set left width equal to right width
+            double left = (b.mean() - a.mean()) / 2;
+            double right = left;
+
+            // scan to next to last element
+            while (it.hasNext()) {
+                if (x < a.mean() + right) {
+                    return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                }
+                r += a.count();
+
+                a = b;
+                b = it.next();
+
+                left = right;
+                right = (b.mean() - a.mean()) / 2;
+            }
+
+            // for the last element, assume right width is same as left
+            left = right;
+            a = b;
+            if (x < a.mean() + right) {
+                return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    /**
+     * @param q The quantile desired.  Can be in the range [0,1].
+     * @return The minimum value x such that we think that the proportion of samples is <= x is q.
+     */
+    public double quantile(double q) {
+        GroupTree values = summary;
+        Preconditions.checkArgument(values.size() > 1);
+
+        Iterator<Group> it = values.iterator();
+        Group center = it.next();
+        Group leading = it.next();
+        if (!it.hasNext()) {
+            // only two centroids because of size limits
+            // both a and b have to have just a single element
+            double diff = (leading.mean() - center.mean()) / 2;
+            if (q > 0.75) {
+                return leading.mean() + diff * (4 * q - 3);
+            } else {
+                return center.mean() + diff * (4 * q - 1);
+            }
+        } else {
+            q *= count;
+            double right = (leading.mean() - center.mean()) / 2;
+            // we have nothing else to go on so make left hanging width same as right to start
+            double left = right;
+
+            double t = center.count();
+            while (it.hasNext()) {
+                if (t + center.count() / 2 >= q) {
+                    // left side of center
+                    return center.mean() - left * 2 * (q - t) / center.count();
+                } else if (t + leading.count() >= q) {
+                    // right of b but left of the left-most thing beyond
+                    return center.mean() + right * 2.0 * (center.count() - (q - t)) / center.count();
+                }
+                t += center.count();
+
+                center = leading;
+                leading = it.next();
+                left = right;
+                right = (leading.mean() - center.mean()) / 2;
+            }
+            // ran out of data ... assume final width is symmetrical
+            center = leading;
+            left = right;
+            if (t + center.count() / 2 >= q) {
+                // left side of center
+                return center.mean() - left * 2 * (q - t) / center.count();
+            } else if (t + leading.count() >= q) {
+                // right of center but left of leading
+                return center.mean() + right * 2.0 * (center.count() - (q - t)) / center.count();
+            } else {
+                // shouldn't be possible
+                return 1;
+            }
+        }
+    }
+
+    public int centroidCount() {
+        return summary.size();
+    }
+
+    public Iterable<? extends Group> centroids() {
+        return summary;
+    }
+
+    public double compression() {
+        return compression;
+    }
+
+    /**
+     * Sets up so that all centroids will record all data assigned to them.  For testing only, really.
+     */
+    public TDigest recordAllData() {
+        recordAllData = true;
+        return this;
+    }
+
+    /**
+     * Returns an upper bound on the number bytes that will be required to represent this histogram.
+     */
+    public int byteSize() {
+        return 4 + 8 + 4 + summary.size() * 12;
+    }
+
+    /**
+     * Returns an upper bound on the number of bytes that will be required to represent this histogram in
+     * the tighter representation.
+     */
+    public int smallByteSize() {
+        int bound = byteSize();
+        ByteBuffer buf = ByteBuffer.allocate(bound);
+        asSmallBytes(buf);
+        return buf.position();
+    }
+
+    public final static int VERBOSE_ENCODING = 1;
+    public final static int SMALL_ENCODING = 2;
+
+    /**
+     * Outputs a histogram as bytes using a particularly cheesy encoding.
+     */
+    public void asBytes(ByteBuffer buf) {
+        buf.putInt(VERBOSE_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+        for (Group group : summary) {
+            buf.putDouble(group.mean());
+        }
+
+        for (Group group : summary) {
+            buf.putInt(group.count());
+        }
+    }
+
+    public void asSmallBytes(ByteBuffer buf) {
+        buf.putInt(SMALL_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+
+        double x = 0;
+        for (Group group : summary) {
+            double delta = group.mean() - x;
+            x = group.mean();
+            buf.putFloat((float) delta);
+        }
+
+        for (Group group : summary) {
+            int n = group.count();
+            encode(buf, n);
+        }
+    }
+
+    public static void encode(ByteBuffer buf, int n) {
+        int k = 0;
+        while (n < 0 || n > 0x7f) {
+            byte b = (byte) (0x80 | (0x7f & n));
+            buf.put(b);
+            n = n >>> 7;
+            k++;
+            Preconditions.checkState(k < 6);
+        }
+        buf.put((byte) n);
+    }
+
+    public static int decode(ByteBuffer buf) {
+        int v = buf.get();
+        int z = 0x7f & v;
+        int shift = 7;
+        while ((v & 0x80) != 0) {
+            Preconditions.checkState(shift <= 28);
+            v = buf.get();
+            z += (v & 0x7f) << shift;
+            shift += 7;
+        }
+        return z;
+    }
+
+    /**
+     * Reads a histogram from a byte buffer
+     *
+     * @return The new histogram structure
+     */
+    public static TDigest fromBytes(ByteBuffer buf) {
+        int encoding = buf.getInt();
+        if (encoding == VERBOSE_ENCODING) {
+            double compression = buf.getDouble();
+            TDigest r = new TDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            for (int i = 0; i < n; i++) {
+                means[i] = buf.getDouble();
+            }
+            for (int i = 0; i < n; i++) {
+                r.add(means[i], buf.getInt());
+            }
+            return r;
+        } else if (encoding == SMALL_ENCODING) {
+            double compression = buf.getDouble();
+            TDigest r = new TDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            double x = 0;
+            for (int i = 0; i < n; i++) {
+                double delta = buf.getFloat();
+                x += delta;
+                means[i] = x;
+            }
+
+            for (int i = 0; i < n; i++) {
+                int z = decode(buf);
+                r.add(means[i], z);
+            }
+            return r;
+        } else {
+            throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+    }
+
+    private Group createGroup(double mean, int id) {
+        return new Group(mean, id, recordAllData);
+    }
+
+    private double interpolate(double x, double x0, double x1) {
+        return (x - x0) / (x1 - x0);
+    }
+
+    public static class Group implements Comparable<Group> {
+        private static final AtomicInteger uniqueCount = new AtomicInteger(1);
+
+        private double centroid = 0;
+        private int count = 0;
+        private int id;
+
+        private List<Double> actualData = null;
+
+        private Group(boolean record) {
+            id = uniqueCount.incrementAndGet();
+            if (record) {
+                actualData = Lists.newArrayList();
+            }
+        }
+
+        public Group(double x) {
+            this(false);
+            start(x, uniqueCount.getAndIncrement());
+        }
+
+        public Group(double x, int id) {
+            this(false);
+            start(x, id);
+        }
+
+        public Group(double x, int id, boolean record) {
+            this(record);
+            start(x, id);
+        }
+
+        private void start(double x, int id) {
+            this.id = id;
+            add(x, 1);
+        }
+
+        public void add(double x, int w) {
+            if (actualData != null) {
+                actualData.add(x);
+            }
+            count += w;
+            centroid += w * (x - centroid) / count;
+        }
+
+        public double mean() {
+            return centroid;
+        }
+
+        public int count() {
+            return count;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        @Override
+        public String toString() {
+            return "Group{" +
+                    "centroid=" + centroid +
+                    ", count=" + count +
+                    '}';
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+
+        @Override
+        public int compareTo(Group o) {
+            int r = Double.compare(centroid, o.centroid);
+            if (r == 0) {
+                r = id - o.id;
+            }
+            return r;
+        }
+
+        public Iterable<? extends Double> data() {
+            return actualData;
+        }
+
+        public static Group createWeighted(double x, int w, Iterable<? extends Double> data) {
+            Group r = new Group(data != null);
+            r.add(x, w, data);
+            return r;
+        }
+
+        private void add(double x, int w, Iterable<? extends Double> data) {
+            if (actualData != null) {
+                if (data != null) {
+                    for (Double old : data) {
+                        actualData.add(old);
+                    }
+                } else {
+                    actualData.add(x);
+                }
+            }
+            count += w;
+            centroid += w * (x - centroid) / count;
+        }
+    }
+
+}

--- a/src/main/java/com/clearspring/analytics/util/AbstractIterator.java
+++ b/src/main/java/com/clearspring/analytics/util/AbstractIterator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Rough and ready clone of the Guava AbstractIterator.  I just did this
+ * to avoid needing to add the guava dependency.  It would be better to
+ * just use quava.
+ */
+public abstract class AbstractIterator<T> implements Iterator<T> {
+    private enum State {
+        NOT_STARTED, DONE, HAS_DATA, EMPTY
+    }
+
+    private T next;
+
+    private State currentState = State.NOT_STARTED;
+
+    @Override
+    public boolean hasNext() {
+        switch (currentState) {
+            case DONE:
+                return false;
+            case NOT_STARTED:
+                currentState = State.HAS_DATA;
+                next = computeNext();
+                break;
+            case HAS_DATA:
+                return true;
+            case EMPTY:
+                currentState = State.HAS_DATA;
+                next = computeNext();
+                break;
+        }
+        return currentState != State.DONE;
+    }
+
+    @Override
+    public T next() {
+        if (hasNext()) {
+            T r = next;
+            currentState = State.EMPTY;
+            return r;
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("Can't remove from an abstract iterator");
+    }
+
+    protected abstract T computeNext();
+
+    public T endOfData() {
+        currentState = State.DONE;
+        return null;
+    }
+}

--- a/src/main/java/com/clearspring/analytics/util/Lists.java
+++ b/src/main/java/com/clearspring/analytics/util/Lists.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Toy version of the guava class.  Only implemented here to avoid adding
+ * a dependency.  It would be better to just depend on guava.
+ */
+public class Lists {
+    public static <T> List<T> newArrayList(Iterable<T> source) {
+        List<T> r = new ArrayList<T>();
+        for (T x : source) {
+            r.add(x);
+        }
+        return r;
+    }
+
+    public static <T> List<T> newArrayList() {
+        return new ArrayList<T>();
+    }
+}

--- a/src/main/java/com/clearspring/analytics/util/Preconditions.java
+++ b/src/main/java/com/clearspring/analytics/util/Preconditions.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.util;
+
+/**
+ * Toy version of the guava class.  Only implemented here to avoid the
+ * extra depenency.
+ */
+public class Preconditions {
+    public static void checkState(boolean condition, String msg) {
+        if (!condition) {
+            throw new IllegalStateException(msg);
+        }
+    }
+
+    public static void checkArgument(boolean condition) {
+        if (!condition) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public static void checkState(boolean condition) {
+        if (!condition) {
+            throw new IllegalStateException();
+        }
+    }
+
+    public static void checkArgument(boolean condition, String format, Object... args) {
+        if (!condition) {
+            throw new IllegalArgumentException(String.format(format, args));
+        }
+    }
+
+    public static void checkState(boolean condition, String format, Object... args) {
+        if (!condition) {
+            throw new IllegalStateException(String.format(format, args));
+        }
+    }
+}

--- a/src/test/java/com/clearspring/analytics/stream/quantile/GroupTreeTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/quantile/GroupTreeTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.stream.quantile;
+
+import com.google.common.collect.Lists;
+import org.apache.mahout.common.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class GroupTreeTest {
+    @Test
+    public void testSimpleAdds() {
+        GroupTree x = new GroupTree();
+        assertNull(x.floor(new TDigest.Group(34)));
+        assertNull(x.ceiling(new TDigest.Group(34)));
+        assertEquals(0, x.size());
+        assertEquals(0, x.sum());
+
+        x.add(new TDigest.Group(1));
+        TDigest.Group group = new TDigest.Group(2);
+        group.add(3, 1);
+        group.add(4, 1);
+        x.add(group);
+
+        assertEquals(2, x.size());
+        assertEquals(4, x.sum());
+    }
+
+    @Test
+    public void testBalancing() {
+        GroupTree x = new GroupTree();
+        for (int i = 0; i < 101; i++) {
+            x.add(new TDigest.Group(i));
+        }
+
+        assertEquals(101, x.sum());
+        assertEquals(101, x.size());
+
+        x.checkBalance();
+    }
+
+    @Test
+    public void testIterators() {
+        GroupTree x = new GroupTree();
+        for (int i = 0; i < 101; i++) {
+            x.add(new TDigest.Group(i / 2));
+        }
+
+        assertEquals(0, x.first().mean(), 0);
+        assertEquals(50, x.last().mean(), 0);
+
+        Iterator<TDigest.Group> ix = x.iterator();
+        for (int i = 0; i < 101; i++) {
+            assertTrue(ix.hasNext());
+            TDigest.Group z = ix.next();
+            assertEquals(i / 2, z.mean(), 0);
+        }
+        assertFalse(ix.hasNext());
+
+        // 34 is special since it is the smallest element of the right hand sub-tree
+        Iterable<TDigest.Group> z = x.tailSet(new TDigest.Group(34, 0));
+        ix = z.iterator();
+        for (int i = 68; i < 101; i++) {
+            assertTrue(ix.hasNext());
+            TDigest.Group v = ix.next();
+            assertEquals(i / 2, v.mean(), 0);
+        }
+        assertFalse(ix.hasNext());
+
+        ix = z.iterator();
+        for (int i = 68; i < 101; i++) {
+            TDigest.Group v = ix.next();
+            assertEquals(i / 2, v.mean(), 0);
+        }
+
+        z = x.tailSet(new TDigest.Group(33, 0));
+        ix = z.iterator();
+        for (int i = 66; i < 101; i++) {
+            assertTrue(ix.hasNext());
+            TDigest.Group v = ix.next();
+            assertEquals(i / 2, v.mean(), 0);
+        }
+        assertFalse(ix.hasNext());
+
+        z = x.tailSet(x.ceiling(new TDigest.Group(34, 0)));
+        ix = z.iterator();
+        for (int i = 68; i < 101; i++) {
+            assertTrue(ix.hasNext());
+            TDigest.Group v = ix.next();
+            assertEquals(i / 2, v.mean(), 0);
+        }
+        assertFalse(ix.hasNext());
+
+        z = x.tailSet(x.floor(new TDigest.Group(34, 0)));
+        ix = z.iterator();
+        for (int i = 67; i < 101; i++) {
+            assertTrue(ix.hasNext());
+            TDigest.Group v = ix.next();
+            assertEquals(i / 2, v.mean(), 0);
+        }
+        assertFalse(ix.hasNext());
+    }
+
+    @Test
+    public void testFloor() {
+        // mostly tested in other tests
+        GroupTree x = new GroupTree();
+        for (int i = 0; i < 101; i++) {
+            x.add(new TDigest.Group(i / 2));
+        }
+
+        assertNull(x.floor(new TDigest.Group(-30)));
+    }
+
+
+    @Test
+    public void testRemoveAndSums() {
+        GroupTree x = new GroupTree();
+        for (int i = 0; i < 101; i++) {
+            x.add(new TDigest.Group(i / 2));
+        }
+        TDigest.Group g = x.ceiling(new TDigest.Group(2, 0));
+        x.remove(g);
+        g.add(3, 1);
+        x.add(g);
+
+        assertEquals(0, x.headCount(new TDigest.Group(-1)));
+        assertEquals(0, x.headSum(new TDigest.Group(-1)));
+        assertEquals(0, x.headCount(new TDigest.Group(0, 0)));
+        assertEquals(0, x.headSum(new TDigest.Group(0, 0)));
+        assertEquals(0, x.headCount(x.ceiling(new TDigest.Group(0, 0))));
+        assertEquals(0, x.headSum(x.ceiling(new TDigest.Group(0, 0))));
+        assertEquals(2, x.headCount(new TDigest.Group(1, 0)));
+        assertEquals(2, x.headSum(new TDigest.Group(1, 0)));
+
+        g = x.tailSet(new TDigest.Group(2.1)).iterator().next();
+        assertEquals(2.5, g.mean(), 1e-9);
+
+        int i = 0;
+        for (TDigest.Group gx : x) {
+            if (i > 10) {
+                break;
+            }
+            System.out.printf("%d:%.1f(%d)\t", i++, gx.mean(), gx.count());
+        }
+        assertEquals(5, x.headCount(new TDigest.Group(2.1, 0)));
+        assertEquals(5, x.headSum(new TDigest.Group(2.1, 0)));
+
+        assertEquals(6, x.headCount(new TDigest.Group(2.7, 0)));
+        assertEquals(7, x.headSum(new TDigest.Group(2.7, 0)));
+
+        assertEquals(101, x.headCount(new TDigest.Group(200)));
+        assertEquals(102, x.headSum(new TDigest.Group(200)));
+    }
+
+    @Before
+    public void setUp() {
+        RandomUtils.useTestSeed();
+    }
+
+    @Test
+    public void testRandomRebalance() {
+        Random gen = RandomUtils.getRandom();
+        GroupTree x = new GroupTree();
+        List<Double> y = Lists.newArrayList();
+        for (int i = 0; i < 1000; i++) {
+            double v = gen.nextDouble();
+            x.add(new TDigest.Group(v));
+            y.add(v);
+            x.checkBalance();
+        }
+
+        Collections.sort(y);
+
+        Iterator<Double> i = y.iterator();
+        for (TDigest.Group group : x) {
+            assertEquals(i.next(), group.mean(), 0.0);
+        }
+
+        for (int j = 0; j < 100; j++) {
+            double v = y.get(gen.nextInt(y.size()));
+            y.remove(v);
+            x.remove(x.floor(new TDigest.Group(v)));
+        }
+
+        Collections.sort(y);
+        i = y.iterator();
+        for (TDigest.Group group : x) {
+            assertEquals(i.next(), group.mean(), 0.0);
+        }
+
+        for (int j = 0; j < y.size(); j++) {
+            double v = y.get(j);
+            y.set(j, v + 10);
+            TDigest.Group g = x.floor(new TDigest.Group(v));
+            x.remove(g);
+            x.checkBalance();
+            g.add(g.mean() + 20, 1);
+            x.add(g);
+            x.checkBalance();
+        }
+
+        i = y.iterator();
+        for (TDigest.Group group : x) {
+            assertEquals(i.next(), group.mean(), 0.0);
+        }
+    }
+}

--- a/src/test/java/com/clearspring/analytics/stream/quantile/TDigestTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/quantile/TDigestTest.java
@@ -1,0 +1,538 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clearspring.analytics.stream.quantile;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.mahout.common.RandomUtils;
+import org.apache.mahout.math.jet.random.AbstractContinousDistribution;
+import org.apache.mahout.math.jet.random.Gamma;
+import org.apache.mahout.math.jet.random.Normal;
+import org.apache.mahout.math.jet.random.Uniform;
+import org.junit.*;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class TDigestTest {
+
+    private static PrintWriter sizeDump;
+    private static PrintWriter errorDump;
+    private static PrintWriter deviationDump;
+
+    @Before
+    public void testSetUp() {
+        RandomUtils.useTestSeed();
+    }
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        sizeDump = new PrintWriter(new FileWriter("sizes.csv"));
+        sizeDump.printf("tag\ti\tq\tk\tactual\n");
+
+        errorDump = new PrintWriter((new FileWriter("errors.csv")));
+        errorDump.printf("dist\ttag\tx\tQ\terror\n");
+
+        deviationDump = new PrintWriter((new FileWriter("deviation.csv")));
+        deviationDump.printf("tag\tQ\tk\tx\tmean\tleft\tright\tdeviation\n");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        sizeDump.close();
+        errorDump.close();
+        deviationDump.close();
+    }
+
+    @After
+    public void flush() {
+        sizeDump.flush();
+        errorDump.flush();
+        deviationDump.flush();
+    }
+
+    @Test
+    public void testUniform() {
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(new Uniform(0, 1, gen), 100,
+                    new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "uniform", true, gen);
+        }
+    }
+
+    @Test
+    public void testGamma() {
+        // this Gamma distribution is very heavily skewed.  The 0.1%-ile is 6.07e-30 while
+        // the median is 0.006 and the 99.9th %-ile is 33.6 while the mean is 1.
+        // this severe skew means that we have to have positional accuracy that
+        // varies by over 11 orders of magnitude.
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(new Gamma(0.1, 0.1, gen), 100,
+//                    new double[]{6.0730483624079e-30, 6.0730483624079e-20, 6.0730483627432e-10, 5.9339110446023e-03,
+//                            2.6615455373884e+00, 1.5884778179295e+01, 3.3636770117188e+01},
+                    new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "gamma", true, gen);
+        }
+    }
+
+    @Test
+    public void testNarrowNormal() {
+        // this mixture of a uniform and normal distribution has a very narrow peak which is centered
+        // near the median.  Our system should be scale invariant and work well regardless.
+        final Random gen = RandomUtils.getRandom();
+        AbstractContinousDistribution mix = new AbstractContinousDistribution() {
+            AbstractContinousDistribution normal = new Normal(0, 1e-5, gen);
+            AbstractContinousDistribution uniform = new Uniform(-1, 1, gen);
+
+            @Override
+            public double nextDouble() {
+                double x;
+                if (gen.nextDouble() < 0.5) {
+                    x = uniform.nextDouble();
+                } else {
+                    x = normal.nextDouble();
+                }
+                return x;
+            }
+        };
+
+        for (int i = 0; i < repeats(); i++) {
+            runTest(mix, 100, new double[]{0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99, 0.999}, "mixture", false, gen);
+        }
+    }
+
+    @Test
+    public void testRepeatedValues() {
+        final Random gen = RandomUtils.getRandom();
+
+        // 5% of samples will be 0 or 1.0.  10% for each of the values 0.1 through 0.9
+        AbstractContinousDistribution mix = new AbstractContinousDistribution() {
+            @Override
+            public double nextDouble() {
+                return Math.rint(gen.nextDouble() * 10) / 10.0;
+            }
+        };
+
+        TDigest dist = new TDigest((double) 1000, gen);
+        long t0 = System.nanoTime();
+        List<Double> data = Lists.newArrayList();
+        for (int i1 = 0; i1 < 100000; i1++) {
+            double x = mix.nextDouble();
+            data.add(x);
+            dist.add(x);
+        }
+
+        System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
+        System.out.printf("# %d centroids\n", dist.centroidCount());
+
+        // I would be happier with 5x compression, but repeated values make things kind of weird
+        assertTrue("Summary is too large", dist.centroidCount() < 10 * (double) 1000);
+
+        // all quantiles should round to nearest actual value
+        for (int i = 0; i < 10; i++) {
+            double z = i / 10.0;
+            // we skip over troublesome points that are nearly halfway between
+            for (double delta : new double[]{0.01, 0.02, 0.03, 0.07, 0.08, 0.09}) {
+                double q = z + delta;
+                double cdf = dist.cdf(q);
+                // we also relax the tolerances for repeated values
+                assertEquals(String.format("z=%.1f, q = %.3f, cdf = %.3f", z, q, cdf), z + 0.05, cdf, 0.005);
+
+                double estimate = dist.quantile(q);
+                assertEquals(String.format("z=%.1f, q = %.3f, cdf = %.3f, estimate = %.3f", z, q, cdf, estimate), Math.rint(q * 10) / 10.0, estimate, 0.001);
+            }
+        }
+    }
+
+    @Test
+    public void testSequentialPoints() {
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(new AbstractContinousDistribution() {
+                double base = 0;
+
+                @Override
+                public double nextDouble() {
+                    base += Math.PI * 1e-5;
+                    return base;
+                }
+            }, 100, new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "sequential", true, gen);
+        }
+    }
+
+    @Test
+    public void testSerialization() {
+        Random gen = RandomUtils.getRandom();
+        TDigest dist = new TDigest(100, gen);
+        for (int i = 0; i < 100000; i++) {
+            double x = gen.nextDouble();
+            dist.add(x);
+        }
+        dist.compress();
+
+        ByteBuffer buf = ByteBuffer.allocate(20000);
+        dist.asBytes(buf);
+        assertTrue(buf.position() < 11000);
+        assertEquals(buf.position(), dist.byteSize());
+        buf.clear();
+
+        dist.asSmallBytes(buf);
+        assertTrue(buf.position() < 6000);
+        assertEquals(buf.position(), dist.smallByteSize());
+
+        System.out.printf("# big %d bytes\n", buf.position());
+
+        buf.flip();
+        TDigest dist2 = TDigest.fromBytes(buf);
+        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.compression(), dist2.compression(), 0);
+        assertEquals(dist.size(), dist2.size());
+
+        for (double q = 0; q < 1; q += 0.01) {
+            assertEquals(dist.quantile(q), dist2.quantile(q), 1e-8);
+        }
+
+        Iterator<? extends TDigest.Group> ix = dist2.centroids().iterator();
+        for (TDigest.Group group : dist.centroids()) {
+            assertTrue(ix.hasNext());
+            assertEquals(group.count(), ix.next().count());
+        }
+        assertFalse(ix.hasNext());
+
+        buf.flip();
+        dist.asSmallBytes(buf);
+        assertTrue(buf.position() < 6000);
+        System.out.printf("# small %d bytes\n", buf.position());
+
+        buf.flip();
+        dist2 = TDigest.fromBytes(buf);
+        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.compression(), dist2.compression(), 0);
+        assertEquals(dist.size(), dist2.size());
+
+        for (double q = 0; q < 1; q += 0.01) {
+            assertEquals(dist.quantile(q), dist2.quantile(q), 1e-6);
+        }
+
+        ix = dist2.centroids().iterator();
+        for (TDigest.Group group : dist.centroids()) {
+            assertTrue(ix.hasNext());
+            assertEquals(group.count(), ix.next().count());
+        }
+        assertFalse(ix.hasNext());
+    }
+
+    @Test
+    public void testIntEncoding() {
+        Random gen = RandomUtils.getRandom();
+        ByteBuffer buf = ByteBuffer.allocate(10000);
+        List<Integer> ref = Lists.newArrayList();
+        for (int i = 0; i < 3000; i++) {
+            int n = gen.nextInt();
+            n = n >>> (i / 100);
+            ref.add(n);
+            TDigest.encode(buf, n);
+        }
+
+        buf.flip();
+
+        for (int i = 0; i < 3000; i++) {
+            int n = TDigest.decode(buf);
+            assertEquals(String.format("%d:", i), ref.get(i).intValue(), n);
+        }
+    }
+
+    @Test
+    public void compareToQDigest() {
+        Random rand = RandomUtils.getRandom();
+
+        for (int i = 0; i < repeats(); i++) {
+            compare(new Gamma(0.1, 0.1, rand), "gamma", 1L << 48, rand);
+            compare(new Uniform(0, 1, rand), "uniform", 1L << 48, rand);
+        }
+    }
+
+    private void compare(AbstractContinousDistribution gen, String tag, long scale, Random rand) {
+        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000}) {
+            QDigest qd = new QDigest(compression);
+            TDigest dist = new TDigest(compression, rand);
+            List<Double> data = Lists.newArrayList();
+            for (int i = 0; i < 100000; i++) {
+                double x = gen.nextDouble();
+                dist.add(x);
+                qd.offer((long) (x * scale));
+                data.add(x);
+            }
+            dist.compress();
+            Collections.sort(data);
+
+            for (double q : new double[]{0.001, 0.01, 0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9, 0.99, 0.999}) {
+                double x1 = dist.quantile(q);
+                double x2 = (double) qd.getQuantile(q) / scale;
+                double e1 = cdf(x1, data) - q;
+                System.out.printf("%s\t%.0f\t%.8f\t%.10g\t%.10g\t%d\t%d\n", tag, compression, q, e1, cdf(x2, data) - q, dist.smallByteSize(), QDigest.serialize(qd).length);
+
+            }
+        }
+    }
+
+    @Test()
+    public void testSizeControl() throws IOException {
+        // very slow running data generator.  Don't want to run this normally.  To run slow tests use
+        // mvn test -DrunSlowTests=true
+        assumeTrue(Boolean.parseBoolean(System.getProperty("runSlowTests")));
+
+        Random gen = RandomUtils.getRandom();
+        PrintWriter out = new PrintWriter(new FileOutputStream("scaling.tsv"));
+        out.printf("k\tsamples\tcompression\tsize1\tsize2\n");
+        for (int k = 0; k < 20; k++) {
+            for (int size : new int[]{10, 100, 1000, 10000}) {
+                for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000}) {
+                    TDigest dist = new TDigest(compression, gen);
+                    for (int i = 0; i < size * 1000; i++) {
+                        dist.add(gen.nextDouble());
+                    }
+                    out.printf("%d\t%d\t%.0f\t%d\t%d\n", k, size, compression, dist.smallByteSize(), dist.byteSize());
+                    out.flush();
+                }
+            }
+        }
+        out.printf("\n");
+        out.close();
+    }
+
+    @Test
+    public void testScaling() throws FileNotFoundException {
+        Random gen = RandomUtils.getRandom();
+        PrintWriter out = new PrintWriter(new FileOutputStream("error-scaling.tsv"));
+        try {
+            out.printf("pass\tcompression\tq\terror\tsize\n");
+            // change to 50 passes for better graphs
+            int n = repeats() * repeats();
+            for (int k = 0; k < n; k++) {
+                List<Double> data = Lists.newArrayList();
+                for (int i = 0; i < 100000; i++) {
+                    data.add(gen.nextDouble());
+                }
+                Collections.sort(data);
+
+                for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000}) {
+                    TDigest dist = new TDigest(compression, gen);
+                    for (Double x : data) {
+                        dist.add(x);
+                    }
+                    dist.compress();
+
+                    for (double q : new double[]{0.001, 0.01, 0.1, 0.5}) {
+                        double estimate = dist.quantile(q);
+                        double actual = data.get((int) (q * data.size()));
+                        out.printf("%d\t%.0f\t%.3f\t%.9f\t%d\n", k, compression, q, estimate - actual, dist.byteSize());
+                        out.flush();
+                    }
+                }
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    /**
+     * Builds estimates of the CDF of a bunch of data points and checks that the centroids are accurately
+     * positioned.  Accuracy is assessed in terms of the estimated CDF which is much more stringent than
+     * checking position of quantiles with a single value for desired accuracy.
+     *
+     * @param gen           Random number generator that generates desired values.
+     * @param sizeGuide     Control for size of the histogram.
+     * @param tag           Label for the output lines
+     * @param recordAllData True if the internal histogrammer should be set up to record all data it sees for
+     *                      diagnostic purposes.
+     * @param rand          a random number generator to inject into TDigests
+     */
+    private void runTest(AbstractContinousDistribution gen, double sizeGuide, double[] qValues, String tag, boolean recordAllData, Random rand) {
+        TDigest dist = new TDigest(sizeGuide, rand);
+        if (recordAllData) {
+            dist.recordAllData();
+        }
+
+        long t0 = System.nanoTime();
+        List<Double> data = Lists.newArrayList();
+        for (int i = 0; i < 100000; i++) {
+            double x = gen.nextDouble();
+            data.add(x);
+            dist.add(x);
+        }
+        dist.compress();
+        Collections.sort(data);
+
+        double[] xValues = qValues.clone();
+        for (int i = 0; i < qValues.length; i++) {
+            double ix = data.size() * qValues[i] - 0.5;
+            int index = (int) Math.floor(ix);
+            double p = ix - index;
+            xValues[i] = data.get(index) * (1 - p) + data.get(index + 1) * p;
+        }
+
+        double qz = 0;
+        int iz = 0;
+        for (TDigest.Group group : dist.centroids()) {
+            double q = (qz + group.count() / 2.0) / dist.size();
+            sizeDump.printf("%s\t%d\t%.6f\t%.3f\t%d\n", tag, iz, q, 4 * q * (1 - q) * dist.size() / dist.compression(), group.count());
+            qz += group.count();
+            iz++;
+        }
+
+        System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
+        System.out.printf("# %d centroids\n", dist.centroidCount());
+
+        assertTrue("Summary is too large", dist.centroidCount() < 10 * sizeGuide);
+        int softErrors = 0;
+        for (int i = 0; i < xValues.length; i++) {
+            double x = xValues[i];
+            double q = qValues[i];
+            double estimate = dist.cdf(x);
+            errorDump.printf("%s\t%s\t%.8g\t%.8f\t%.8f\n", tag, "cdf", x, q, estimate - q);
+            assertEquals(q, estimate, 0.005);
+
+            estimate = cdf(dist.quantile(q), data);
+            errorDump.printf("%s\t%s\t%.8g\t%.8f\t%.8f\n", tag, "quantile", x, q, estimate - q);
+            if (Math.abs(q - estimate) > 0.005) {
+                softErrors++;
+            }
+            assertEquals(q, estimate, 0.012);
+        }
+        assertTrue(softErrors < 3);
+
+        if (recordAllData) {
+            Iterator<? extends TDigest.Group> ix = dist.centroids().iterator();
+            TDigest.Group b = ix.next();
+            TDigest.Group c = ix.next();
+            qz = b.count();
+            while (ix.hasNext()) {
+                TDigest.Group a = b;
+                b = c;
+                c = ix.next();
+                double left = (b.mean() - a.mean()) / 2;
+                double right = (c.mean() - b.mean()) / 2;
+
+                double q = (qz + b.count() / 2.0) / dist.size();
+                for (Double x : b.data()) {
+                    deviationDump.printf("%s\t%.5f\t%d\t%.5g\t%.5g\t%.5g\t%.5g\t%.5f\n", tag, q, b.count(), x, b.mean(), left, right, (x - b.mean()) / (right + left));
+                }
+                qz += a.count();
+            }
+        }
+    }
+
+    @Test
+    public void testMerge() {
+        Random gen = RandomUtils.getRandom();
+
+        for (int parts : new int[]{2, 5, 10, 20, 50, 100}) {
+            List<Double> data = Lists.newArrayList();
+
+            TDigest dist = new TDigest(100, gen);
+            dist.recordAllData();
+
+            List<TDigest> many = Lists.newArrayList();
+            for (int i = 0; i < 100; i++) {
+                many.add(new TDigest(100, gen).recordAllData());
+            }
+
+            // we accumulate the data into multiple sub-digests
+            List<TDigest> subs = Lists.newArrayList();
+            for (int i = 0; i < parts; i++) {
+                subs.add(new TDigest(50, gen).recordAllData());
+            }
+
+            for (int i = 0; i < 100000; i++) {
+                double x = gen.nextDouble();
+                data.add(x);
+                dist.add(x);
+                subs.get(i % parts).add(x);
+            }
+            dist.compress();
+            Collections.sort(data);
+
+            // collect the raw data from the sub-digests
+            List<Double> data2 = Lists.newArrayList();
+            for (TDigest digest : subs) {
+                for (TDigest.Group group : digest.centroids()) {
+                    Iterables.addAll(data2, group.data());
+                }
+            }
+            Collections.sort(data2);
+
+            // verify that the raw data all got recorded
+            assertEquals(data.size(), data2.size());
+            Iterator<Double> ix = data.iterator();
+            for (Double x : data2) {
+                assertEquals(ix.next(), x);
+            }
+
+            // now merge the sub-digests
+            TDigest dist2 = TDigest.merge(50, subs);
+
+            for (double q : new double[]{0.001, 0.01, 0.1, 0.2, 0.3, 0.5}) {
+                double z = quantile(q, data);
+                double e1 = dist.quantile(q) - z;
+                double e2 = dist2.quantile(q) - z;
+                System.out.printf("quantile\t%d\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\n", parts, q, z - q, e1, e2, Math.abs(e2) / q);
+                assertTrue(String.format("parts=%d, q=%.4f, e1=%.5f, e2=%.5f, rel=%.4f", parts, q, e1, e2, Math.abs(e2) / q), Math.abs(e2) / q < 0.1);
+                assertTrue(String.format("parts=%d, q=%.4f, e1=%.5f, e2=%.5f, rel=%.4f", parts, q, e1, e2, Math.abs(e2) / q), Math.abs(e2) < 0.015);
+            }
+
+            for (double x : new double[]{0.001, 0.01, 0.1, 0.2, 0.3, 0.5}) {
+                double z = cdf(x, data);
+                double e1 = dist.cdf(x) - z;
+                double e2 = dist2.cdf(x) - z;
+
+                System.out.printf("cdf\t%d\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\n", parts, x, z - x, e1, e2, Math.abs(e2) / x);
+                assertTrue(String.format("parts=%d, x=%.4f, e1=%.5f, e2=%.5f", parts, x, e1, e2), Math.abs(e2) < 0.015);
+                assertTrue(String.format("parts=%d, x=%.4f, e1=%.5f, e2=%.5f", parts, x, e1, e2), Math.abs(e2) / x < 0.1);
+            }
+        }
+    }
+
+    private double cdf(final double x, List<Double> data) {
+        int n1 = 0;
+        int n2 = 0;
+        for (Double v : data) {
+            n1 += (v < x) ? 1 : 0;
+            n2 += (v <= x) ? 1 : 0;
+        }
+        return (n1 + n2) / 2.0 / data.size();
+    }
+
+    private double quantile(final double q, List<Double> data) {
+        return data.get((int) Math.floor(data.size() * q));
+    }
+
+    private int repeats() {
+        return Boolean.parseBoolean(System.getProperty("runSlowTests")) ? 10 : 1;
+    }
+}


### PR DESCRIPTION
This port required a few uglinesses:
- I re-implemented a bit of guava (Preconditions, Lists, that sort of thing) even though guava is listed as a test dependency for stream-lib.  It would be better to just depend on guava.
- I added Mahout math as a test dependency in order to get some special distributions for testing.  I note that stream-lib depends on colt, pretty much all of which has been subsumed into Mahout math.  In the process of sucking that code in, we found a lot of errors.  It would be better to pull in Mahout math directly.
