### PR TITLE
Fix StreamSummary when incrementCount > 1

### DIFF
--- a/src/test/java/com/clearspring/analytics/stream/TestStreamSummary.java
+++ b/src/test/java/com/clearspring/analytics/stream/TestStreamSummary.java
@@ -87,6 +87,33 @@ public class TestStreamSummary
     }
 
     @Test
+    public void testTopKWithIncrementOutOfOrder()
+    {
+        StreamSummary<String> vs_increment = new StreamSummary<String>(3);
+        StreamSummary<String> vs_single = new StreamSummary<String>(3);
+        String[] stream = {"A","B","C","D","A"};
+        Integer[] increments = {15,20,25,30,1};
+
+        for (int i=0;i<stream.length;i++) {
+            vs_increment.offer(stream[i],increments[i]);
+            for (int k=0;k<increments[i];k++) {
+                vs_single.offer(stream[i]);
+            }
+        }
+        System.out.println("Insert with counts vs. single inserts:");
+        System.out.println(vs_increment);
+        System.out.println(vs_single);
+
+        List<Counter<String>> topK_increment = vs_increment.topK(3);
+        List<Counter<String>> topK_single = vs_single.topK(3);
+
+        for (int i=0;i<topK_increment.size();i++) {
+            assertEquals(topK_increment.get(i).getItem(),
+                    topK_single.get(i).getItem());
+        }
+    }
+
+    @Test
     public void testGeometricDistribution()
     {
         StreamSummary<Integer> vs = new StreamSummary<Integer>(10);


### PR DESCRIPTION
There appears to be a bug in how incrementCounter ( 
https://github.com/addthis/stream-lib/blob/master/src/main/java/com/clearspring/analytics/stream/StreamSummary.java#L154 ) is implemented for counts > 1.

The top-k Space-Saving paper at https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf assumes that whenever an item is seen, you’re only ever incrementing the count by 1. Given the way they create and merge buckets, the list of counts is always in descending order (the counts may be off by a large error, but the buckets are always ordered using the item count, ignoring whatever the error is set to.)

This implementation of incrementCounter() allows you to increment by more than one, but it allows our list of stream counts to get out of order: if I have counts A:8,B:6,C:5 in the stream, and I add D:10, the Space-Saving algorithm suggests it should bubble to the top: D:10,A:8,B:6,C:5.
But in this case it doesn’t: I get A:8,B:6,C:5,D:10. 

Since every add only checks to see if the bucket above it is equal to the new count for the item being added (line ref aboved), any new item added with either replace the D:10 bucket or be added below it, unless you add an item after it with count < 10 and then increment() enough to bring the count up to 10. Since the algorithm drops the last bucket in the list (calls it “min”, even though in this case it’s not), you get stuck dropping and replacing the last item all the time.

Meanwhile, the peek function the top-K items, assumes the buckets are in order:
https://github.com/addthis/stream-lib/blob/master/src/main/java/com/clearspring/analytics/stream/StreamSummary.java#L196
