### PR TITLE
HyperLogLog Bug - merging counters with custom RegisterSet size

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
@@ -239,7 +239,7 @@ public class HyperLogLog implements ICardinality
     @Override
     public ICardinality merge(ICardinality... estimators) throws CardinalityMergeException
     {
-        HyperLogLog merged = new HyperLogLog(log2m);
+        HyperLogLog merged = new HyperLogLog(log2m, new RegisterSet(this.registerSet.count));
         merged.addAll(this);
 
         if (estimators == null)

--- a/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLog.java
+++ b/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLog.java
@@ -129,6 +129,18 @@ public class TestHyperLogLog
         assertEquals(mergedEstimate, baselineEstimate);
     }
 
+    /**
+     * should not fail with HyperLogLogMergeException: "Cannot merge estimators of different sizes"
+     * */
+    @Test
+    public void testMergeWithRegisterSet() throws CardinalityMergeException {
+        HyperLogLog first = new HyperLogLog(16, new RegisterSet(1 << 20));
+        HyperLogLog second = new HyperLogLog(16, new RegisterSet(1 << 20));
+        first .offer(0);
+        second.offer(1);
+        first.merge(second);
+    }
+
     @Test
     @Ignore
     public void testPrecise() throws CardinalityMergeException


### PR DESCRIPTION
BugFix in HyperLogLog
When merging two counters with custom register sets, exception is thrown
