### PR TITLE
Make Varint#writeUnsignedVarInt(int) thread-safe

### DIFF
--- a/src/main/java/com/clearspring/analytics/util/Varint.java
+++ b/src/main/java/com/clearspring/analytics/util/Varint.java
@@ -21,8 +21,6 @@ package com.clearspring.analytics.util;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
@@ -114,10 +112,9 @@ public final class Varint
      *      This one does not use streams and is much faster.
      *      Makes a single object each time, and that object is a primitive array.
      */
-    static byte[] byteArrayList = new byte[10];
-
     public static byte[] writeUnsignedVarInt(int value)
     {
+        byte[] byteArrayList = new byte[10];
         int i = 0;
         while ((value & 0xFFFFFF80) != 0L)
         {


### PR DESCRIPTION
Although Varint#writeUnsignedVarInt(int) isn't used anywhere of importance (right now), this change makes it thread-safe (instead of using a static byte buffer) in case it does get used in a more prominent way in the future. This will prevent inadvertent introduction of thread-safety issues elsewhere.
