### PR TITLE
Remove outdated misleading comment.

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/CountThenEstimate.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/CountThenEstimate.java
@@ -39,8 +39,6 @@ import com.clearspring.analytics.util.IBuilder;
  * Avoids allocating a large block of memory for cardinality estimation until
  * a specified "tipping point" cardinality is reached.
  * </p>
- * <p/>
- * Currently supports serialization with LinearCounting or AdaptiveCounting
  */
 public class CountThenEstimate implements ICardinality, Externalizable {
 


### PR DESCRIPTION
This comment seems to be outdated and thus should be removed (or replaced by an up to date list of supported methods, which then might get outdated later again).
