### PR TITLE
add merge functionality to BloomFilter

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/membership/BloomFilter.java
+++ b/src/main/java/com/clearspring/analytics/stream/membership/BloomFilter.java
@@ -118,7 +118,7 @@ public class BloomFilter extends Filter {
         return n;
     }
 
-    public void addAll(BloomFilter other) throws IllegalArgumentException {
+    public void addAll(BloomFilter other) {
         if (this.getHashCount() != other.getHashCount()) {
             throw new IllegalArgumentException("Cannot merge filters of different sizes");
         }
@@ -126,7 +126,7 @@ public class BloomFilter extends Filter {
         this.filter().or(other.filter());
     }
 
-    public Filter merge(Filter... filters) throws IllegalArgumentException {
+    public Filter merge(Filter... filters) {
         BloomFilter merged = new BloomFilter(this.getHashCount(), (BitSet) this.filter().clone());
 
         if (filters == null) {

--- a/src/test/java/com/clearspring/analytics/stream/membership/BloomFilterTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/membership/BloomFilterTest.java
@@ -65,7 +65,7 @@ public class BloomFilterTest {
     }
 
     @Test
-    public void testMerge() throws IllegalArgumentException {
+    public void testMerge() {
         bf.add("a");
         bf2.add("c");
         BloomFilter[] bfs = new BloomFilter[1];
@@ -77,7 +77,7 @@ public class BloomFilterTest {
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void testMergeException() throws IllegalArgumentException {
+    public void testMergeException() {
         BloomFilter bf3 = new BloomFilter(ELEMENTS*10, 1);
         BloomFilter[] bfs = new BloomFilter[1];
         bfs[0] = bf;


### PR DESCRIPTION
Essentially uses `BitSet`'s `or` method. I used the `HyperLogLog`'s merge mechanism as a model. Includes a new `MembershipMergeException` class and a couple simple tests.
