### PR TITLE
Make MurmurHash of Strings independent of default encoding

### DIFF
--- a/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
+++ b/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
@@ -1,6 +1,7 @@
 package com.clearspring.analytics.hash;
 
-import com.google.common.base.Charsets;
+import java.nio.charset.Charset;
+
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -47,7 +48,7 @@ public class MurmurHash {
             return hashLong(Float.floatToRawIntBits((Float) o));
         }
         if (o instanceof String) {
-            return hash(((String) o).getBytes(Charsets.UTF_8));
+            return hash(((String) o).getBytes(Charset.forName("UTF8")));
         }
         if (o instanceof byte[]) {
             return hash((byte[]) o);
@@ -138,7 +139,7 @@ public class MurmurHash {
         if (o == null) {
             return 0l;
         } else if (o instanceof String) {
-            final byte[] bytes = ((String) o).getBytes(Charsets.UTF_8);
+            final byte[] bytes = ((String) o).getBytes(Charset.forName("UTF8"));
             return hash64(bytes, bytes.length);
         } else if (o instanceof byte[]) {
             final byte[] bytes = (byte[]) o;


### PR DESCRIPTION
When hashing Strings MurmurHash simply uses the getBytes() method, which
will use the default platform encoding. This is not portable.

I've changed all calls to getBytes(Charset) and fixed the encoding to UTF8.
