### PR TITLE
Improve heap usage of low cardinality hllp counters.

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -304,7 +304,7 @@ public class HyperLogLogPlus implements ICardinality, Serializable {
                 //Put the encoded data into the temp set
                 tmpSet[tmpIndex++] = k;
                 if (tmpIndex >= tmpSet.length) {
-                    mergeTempList(true);
+                    mergeTempList();
                 }
                 return true;
         }
@@ -742,21 +742,17 @@ public class HyperLogLogPlus implements ICardinality, Serializable {
      * is determined by {@link #SPARSE_SET_TEMP_SET_RATIO}. The temp set will not
      * grow unless it is currently smaller by 1/2 of the target size.
      */
-    void mergeTempList(boolean resizeTmpSet) {
+    void mergeTempList() {
         if (tmpIndex > 0) {
             int[] sortedSet = sortEncodedSet(tmpSet, tmpIndex);
             sparseSet = merge(sparseSet, sortedSet);
             tmpIndex = 0;
             if (sparseSet.length > sparseSetThreshold) {
                 convertToNormal();
-            } else if (resizeTmpSet && (tmpSet.length * 2) < (sparseSet.length / SPARSE_SET_TEMP_SET_RATIO)) {
+            } else if ((tmpSet.length * 2) < (sparseSet.length / SPARSE_SET_TEMP_SET_RATIO)) {
                 tmpSet = new int[sparseSet.length / SPARSE_SET_TEMP_SET_RATIO];
             }
         }
-    }
-
-    void mergeTempList() {
-        mergeTempList(false);
     }
 
     int[] sortEncodedSet(int[] encodedSet, int validIndex) {

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -64,7 +64,7 @@ public class HyperLogLogPlus implements ICardinality, Serializable {
 
     public static final int[] EMPTY_SPARSE = new int[0];
 
-    private static final int INITIAL_TEMP_SET_CAPACITY = 64;
+    private static final int INITIAL_TEMP_SET_CAPACITY = 4;
 
     /**
      * Ratio of the sparse set size to the temp set size.

--- a/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
+++ b/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
@@ -81,6 +81,10 @@ public class TestHyperLogLogPlus {
                 hllpp1.offer(strings[i]);
                 hllpp2.offer(strings[n - 1 - i]);
             }
+            // calling these here ensures their internal state (format type) is stable for the rest of these checks.
+            // (end users have no need for this because they cannot access the format directly anyway)
+            hllpp1.mergeTempList();
+            hllpp2.mergeTempList();
             log.debug("n={} format1={} format2={}", n, hllpp1.format, hllpp2.format);
             try {
                 if (hllpp1.format == hllpp2.format) {

--- a/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
+++ b/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
@@ -171,21 +171,6 @@ public class TestHyperLogLogPlus {
         assertTrue(estimate <= expectedCardinality + (3 * se));
     }
 
-//    @Test
-//    public void testDelta()
-//    {
-//        HyperLogLogPlus hll = new HyperLogLogPlus(14, 25);
-//        ArrayList<byte[]> l = new ArrayList<byte[]>();
-//        for (int i = 0; i < 1000000; i++)
-//        {
-//            hll.deltaAdd(l,i);
-//            int out = hll.deltaRead(l,i);
-//            assert i == out;
-//            int out2 = hll.deltaRead(l,i);
-//            assert i == out2;
-//        }
-//    }
-
     @Test
     public void testSerialization_Normal() throws IOException {
         HyperLogLogPlus hll = new HyperLogLogPlus(5, 25);


### PR DESCRIPTION
Low cardinality hllp counters should have a temp set
size that is proportional to the current sparse set
size. The previous implementation had a temp set size
that was proportional to the maximum sparse set size.
Ref T53112.