### PR TITLE
HLL++ - Corrected threshold typo for precision 14

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -79,7 +79,7 @@ public class HyperLogLogPlus implements ICardinality, Serializable {
     private static final int VERSION = 2;
 
     // threshold and bias data taken from google's bias correction data set:  https://docs.google.com/document/d/1gyjfMHy43U9OWBXxfaeG-3MjGzejW1dlpyMwEYAAWEI/view?fullscreen#
-    static final double[] thresholdData = {10, 20, 40, 80, 220, 400, 900, 1800, 3100, 6500, 15500, 20000, 50000, 120000, 350000};
+    static final double[] thresholdData = {10, 20, 40, 80, 220, 400, 900, 1800, 3100, 6500, 11500, 20000, 50000, 120000, 350000};
 
     static final double[][] rawEstimateData = {
             // precision 4


### PR DESCRIPTION
Hi,
I'm just correcting a small typo for the threshold value at precision 14, when using HyperLogLog++.
15500 -> 11500.
This implies that we'll switch earlier from LinearCounting to a bias-corrected estimate.

(Based on the Appendix of the "HyperLogLog in Practice" paper by google engineers, to be found here http://goo.gl/iU8Ig)