### PR TITLE
fixed breaking serialization

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -757,19 +757,19 @@ public class HyperLogLogPlus implements ICardinality, Serializable {
 
     private static int transformToSortRepresentation(int x) {
         if ((x & 1) == 0) {
-            return (x << 6) ^ 0x7F;
+            return (x << 6) ^ 0x8000007F;
         }
         else {
-            return x ^ 1;
+            return x ^ 0x80000001;
         }
     }
 
     private static int transformFromSortRepresentation(int x) {
         if ((x & 1) == 1) {
-            return (x >>> 6) ^ 1;
+            return (x ^ 0x80000040) >>> 6;
         }
         else {
-            return x ^ 1;
+            return x ^ 0x80000001;
         }
     }
 

--- a/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
+++ b/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
@@ -496,4 +496,16 @@ public class TestHyperLogLogPlus {
         a.addAll(b);
         assertEquals(14, a.cardinality());
     }
+    
+    @Test
+    public void testSerializationWithNewSortMethod() throws IOException {
+        HyperLogLogPlus hll = new HyperLogLogPlus(14, 25);
+        hll.offerHashed(0x0000000000000000l);
+        hll.offerHashed(0x7FFFFFFFFFFFFFFFl);
+        hll.offerHashed(0x8000000000000000l);
+        hll.offerHashed(0xFFFFFFFFFFFFFFFFl);
+
+        // test against old serialization
+        assertArrayEquals(new byte[]{-1, -1, -1, -2, 14, 25, 1, 4, 25, -27, -1, -1, 15, -101, -128, -128, -16, 7, -27, -1, -1, -97, 8}, hll.getBytes());
+    }
 }


### PR DESCRIPTION
I have realized that my commit b05dbce28a6dab82f20f31e4da28b29d2b736cef changed serialization for the case sp=25, because the sorting order was changed. We also need to flip the first
bit to have same ordering as before. I have also added a unit test that fails for b05dbce28a6dab82f20f31e4da28b29d2b736cef and that demonstrates the problem.