### PR TITLE
Update link in comment to not be broken

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/frequency/CountMinSketch.java
+++ b/src/main/java/com/clearspring/analytics/stream/frequency/CountMinSketch.java
@@ -28,7 +28,7 @@ import com.clearspring.analytics.stream.membership.Filter;
 /**
  * Count-Min Sketch datastructure.
  * An Improved Data Stream Summary: The Count-Min Sketch and its Applications
- * http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf
+ * https://web.archive.org/web/20060907232042/http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf
  */
 public class CountMinSketch implements IFrequency {
 


### PR DESCRIPTION
The link to the Count-Min Sketch paper is now broken, but the internet archive wayback machine still has a copy.