### PR TITLE
Add a CountMinSketch with short values for lesser memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pom.xml.versionsBackup
 target/
 pom.xml.releaseBackup
 release.properties
+*.iml

--- a/src/main/java/com/clearspring/analytics/stream/frequency/ShortCountMinSketch.java
+++ b/src/main/java/com/clearspring/analytics/stream/frequency/ShortCountMinSketch.java
@@ -1,0 +1,355 @@
+package com.clearspring.analytics.stream.frequency;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Random;
+
+import com.clearspring.analytics.stream.membership.Filter;
+import com.clearspring.analytics.util.Preconditions;
+
+public class ShortCountMinSketch implements IFrequency, Serializable {
+
+   public static final long PRIME_MODULUS = (1L << 31) - 1;
+   private static final long serialVersionUID = -5084982213094657923L;
+
+   int depth;
+   int width;
+   short[][] table;
+   long[] hashA;
+   long size;
+   double eps;
+   double confidence;
+
+   ShortCountMinSketch() {
+   }
+
+   public ShortCountMinSketch(int depth, int width, int seed) {
+      this.depth = depth;
+      this.width = width;
+      this.eps = 2.0 / width;
+      this.confidence = 1 - 1 / Math.pow(2, depth);
+      initTablesWith(depth, width, seed);
+   }
+
+   public ShortCountMinSketch(double epsOfTotalCount, double confidence, int seed) {
+      // 2/w = eps ; w = 2/eps
+      // 1/2^depth <= 1-confidence ; depth >= -log2 (1-confidence)
+      this.eps = epsOfTotalCount;
+      this.confidence = confidence;
+      this.width = (int) Math.ceil(2 / epsOfTotalCount);
+      this.depth = (int) Math.ceil(-Math.log(1 - confidence) / Math.log(2));
+      initTablesWith(depth, width, seed);
+   }
+
+   ShortCountMinSketch(int depth, int width, long size, long[] hashA, short[][] table) {
+      this.depth = depth;
+      this.width = width;
+      this.eps = 2.0 / width;
+      this.confidence = 1 - 1 / Math.pow(2, depth);
+      this.hashA = hashA;
+      this.table = table;
+
+      Preconditions.checkState(size >= 0, "The size cannot be smaller than ZER0: " + size);
+      this.size = size;
+   }
+
+   @Override
+   public String toString() {
+      return "ShortCountMinSketch{" +
+            "eps=" + eps +
+            ", confidence=" + confidence +
+            ", depth=" + depth +
+            ", width=" + width +
+            ", size=" + size +
+            '}';
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      final ShortCountMinSketch that = (ShortCountMinSketch) o;
+
+      if (depth != that.depth) {
+         return false;
+      }
+      if (width != that.width) {
+         return false;
+      }
+
+      if (Double.compare(that.eps, eps) != 0) {
+         return false;
+      }
+      if (Double.compare(that.confidence, confidence) != 0) {
+         return false;
+      }
+
+      if (size != that.size) {
+         return false;
+      }
+
+      if (!Arrays.deepEquals(table, that.table)) {
+         return false;
+      }
+      return Arrays.equals(hashA, that.hashA);
+   }
+
+   @Override
+   public int hashCode() {
+      int result;
+      long temp;
+      result = depth;
+      result = 31 * result + width;
+      result = 31 * result + Arrays.deepHashCode(table);
+      result = 31 * result + Arrays.hashCode(hashA);
+      result = 31 * result + (int) (size ^ (size >>> 32));
+      temp = Double.doubleToLongBits(eps);
+      result = 31 * result + (int) (temp ^ (temp >>> 32));
+      temp = Double.doubleToLongBits(confidence);
+      result = 31 * result + (int) (temp ^ (temp >>> 32));
+      return result;
+   }
+
+   private void initTablesWith(int depth, int width, int seed) {
+      this.table = new short[depth][width];
+      this.hashA = new long[depth];
+      Random r = new Random(seed);
+      // We're using a linear hash functions
+      // of the form (a*x+b) mod p.
+      // a,b are chosen independently for each hash function.
+      // However we can set b = 0 as all it does is shift the results
+      // without compromising their uniformity or independence with
+      // the other hashes.
+      for (int i = 0; i < depth; ++i) {
+         hashA[i] = r.nextInt(Integer.MAX_VALUE);
+      }
+   }
+
+   public double getRelativeError() {
+      return eps;
+   }
+
+   public double getConfidence() {
+      return confidence;
+   }
+
+   int hash(long item, int i) {
+      long hash = hashA[i] * item;
+      // A super fast way of computing x mod 2^p-1
+      // See http://www.cs.princeton.edu/courses/archive/fall09/cos521/Handouts/universalclasses.pdf
+      // page 149, right after Proposition 7.
+      hash += hash >> 32;
+      hash &= PRIME_MODULUS;
+      // Doing "%" after (int) conversion is ~2x faster than %'ing longs.
+      return ((int) hash) % width;
+   }
+
+   private static void checkSizeAfterOperation(long previousSize, String operation, long newSize) {
+      if (newSize < previousSize) {
+         throw new IllegalStateException("Overflow error: the size after calling `" + operation +
+               "` is smaller than the previous size. " +
+               "Previous size: " + previousSize +
+               ", New size: " + newSize);
+      }
+   }
+
+   private void checkSizeAfterAdd(String item, long count) {
+      long previousSize = size;
+      size += count;
+      checkSizeAfterOperation(previousSize, "add(" + item + "," + count + ")", size);
+   }
+
+   public void addOne(long item) {
+      add(item, (short) 1);
+
+      checkSizeAfterAdd(String.valueOf(item), (short) 1);
+   }
+
+   @Override
+   public void add(long item, long count) {
+      if (count < 0) {
+         // Actually for negative increments we'll need to use the median
+         // instead of minimum, and accuracy will suffer somewhat.
+         // Probably makes sense to add an "allow negative increments"
+         // parameter to constructor.
+         throw new IllegalArgumentException("Negative increments not implemented");
+      }
+      if (count > Short.MAX_VALUE) {
+         count = Short.MAX_VALUE;
+      }
+
+      for (int i = 0; i < depth; ++i) {
+         int hash = hash(item, i);
+         table[i][hash] += count;
+         // check for short overflow
+         if (table[i][hash] < 0) {
+            table[i][hash] = Short.MAX_VALUE;
+         }
+      }
+
+      checkSizeAfterAdd(String.valueOf(item), count);
+   }
+
+   @Override
+   public void add(String item, long count) {
+      if (count < 0) {
+         // Actually for negative increments we'll need to use the median
+         // instead of minimum, and accuracy will suffer somewhat.
+         // Probably makes sense to add an "allow negative increments"
+         // parameter to constructor.
+         throw new IllegalArgumentException("Negative increments not implemented");
+      }
+      if (count > Short.MAX_VALUE) {
+         count = Short.MAX_VALUE;
+      }
+      int[] buckets = Filter.getHashBuckets(item, depth, width);
+      for (int i = 0; i < depth; ++i) {
+         int bucket = buckets[i];
+         table[i][bucket] += count;
+         // check for short overflow
+         if (table[i][bucket] < 0) {
+            table[i][bucket] = Short.MAX_VALUE;
+         }
+      }
+
+      checkSizeAfterAdd(item, count);
+   }
+
+   @Override
+   public long size() {
+      return size;
+   }
+
+   /**
+    * The estimate is correct within 'epsilon' * (total item count), with probability 'confidence'.
+    */
+   @Override
+   public long estimateCount(long item) {
+      short res = Short.MAX_VALUE;
+      for (int i = 0; i < depth; ++i) {
+         // cast is possible due to table stores just short values
+         res = (short) Math.min(res, table[i][hash(item, i)]);
+      }
+      return res;
+   }
+
+   @Override
+   public long estimateCount(String item) {
+      short res = Short.MAX_VALUE;
+      int[] buckets = Filter.getHashBuckets(item, depth, width);
+      for (int i = 0; i < depth; ++i) {
+         // cast is possible due to table stores just short values
+         res = (short) Math.min(res, table[i][buckets[i]]);
+      }
+      return res;
+   }
+
+   /**
+    * Merges count min sketches to produce a count min sketch for their combined streams
+    *
+    * @param estimators
+    * @return merged estimator or null if no estimators were provided
+    * @throws CMSMergeException
+    *            if estimators are not mergeable (same depth, width and seed)
+    */
+   public static ShortCountMinSketch merge(ShortCountMinSketch... estimators) throws CMSMergeException {
+      ShortCountMinSketch merged = null;
+      if (estimators != null && estimators.length > 0) {
+         int depth = estimators[0].depth;
+         int width = estimators[0].width;
+         long[] hashA = Arrays.copyOf(estimators[0].hashA, estimators[0].hashA.length);
+
+         short[][] table = new short[depth][width];
+         long size = 0;
+
+         for (ShortCountMinSketch estimator : estimators) {
+            if (estimator.depth != depth) {
+               throw new CMSMergeException("Cannot merge estimators of different depth");
+            }
+            if (estimator.width != width) {
+               throw new CMSMergeException("Cannot merge estimators of different width");
+            }
+            if (!Arrays.equals(estimator.hashA, hashA)) {
+               throw new CMSMergeException("Cannot merge estimators of different seed");
+            }
+
+            for (int i = 0; i < table.length; i++) {
+               for (int j = 0; j < table[i].length; j++) {
+                  table[i][j] += estimator.table[i][j];
+               }
+            }
+
+            long previousSize = size;
+            size += estimator.size;
+            checkSizeAfterOperation(previousSize, "merge(" + estimator + ")", size);
+         }
+
+         merged = new ShortCountMinSketch(depth, width, size, hashA, table);
+      }
+
+      return merged;
+   }
+
+   public static byte[] serialize(ShortCountMinSketch sketch) {
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      DataOutputStream s = new DataOutputStream(bos);
+      try {
+         s.writeLong(sketch.size);
+         s.writeInt(sketch.depth);
+         s.writeInt(sketch.width);
+         for (int i = 0; i < sketch.depth; ++i) {
+            s.writeLong(sketch.hashA[i]);
+            for (int j = 0; j < sketch.width; ++j) {
+               s.writeShort(sketch.table[i][j]);
+            }
+         }
+         return bos.toByteArray();
+      } catch (IOException e) {
+         // Shouldn't happen
+         throw new RuntimeException(e);
+      }
+   }
+
+   public static ShortCountMinSketch deserialize(byte[] data) {
+      ByteArrayInputStream bis = new ByteArrayInputStream(data);
+      DataInputStream s = new DataInputStream(bis);
+      try {
+         ShortCountMinSketch sketch = new ShortCountMinSketch();
+         sketch.size = s.readLong();
+         sketch.depth = s.readInt();
+         sketch.width = s.readInt();
+         sketch.eps = 2.0 / sketch.width;
+         sketch.confidence = 1 - 1 / Math.pow(2, sketch.depth);
+         sketch.hashA = new long[sketch.depth];
+         sketch.table = new short[sketch.depth][sketch.width];
+         for (int i = 0; i < sketch.depth; ++i) {
+            sketch.hashA[i] = s.readLong();
+            for (int j = 0; j < sketch.width; ++j) {
+               sketch.table[i][j] = s.readShort();
+            }
+         }
+         return sketch;
+      } catch (IOException e) {
+         // Shouldn't happen
+         throw new RuntimeException(e);
+      }
+   }
+
+   @SuppressWarnings("serial")
+   protected static class CMSMergeException extends FrequencyMergeException {
+
+      public CMSMergeException(String message) {
+         super(message);
+      }
+   }
+}

--- a/src/test/java/com/clearspring/analytics/stream/frequency/ShortCountMinSketchTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/frequency/ShortCountMinSketchTest.java
@@ -1,0 +1,312 @@
+package com.clearspring.analytics.stream.frequency;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.clearspring.analytics.stream.frequency.ShortCountMinSketch.CMSMergeException;
+
+public class ShortCountMinSketchTest {
+   /*
+    * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+    * with the License. You may obtain a copy of the License at
+    *
+    * http://www.apache.org/licenses/LICENSE-2.0
+    *
+    * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+    * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    * the specific language governing permissions and limitations under the License.
+    */
+
+   @Test(expected = IllegalStateException.class)
+   public void negativeSize() {
+      new ShortCountMinSketch(20, 4, (short) -1, new long[] { 1 }, new short[][] { { 10, 20 }, { 100, 200 } });
+   }
+
+   @Test
+   public void testSize() throws CMSMergeException {
+      ShortCountMinSketch sketch = new ShortCountMinSketch(0.00001, 0.99999, 1);
+      assertEquals(0, sketch.size(), 0);
+
+      sketch.add(1, (short) 11);
+      sketch.add(2, (short) 22);
+      sketch.add(3, (short) 33);
+
+      long expectedSize = 11 + 22 + 33;
+      assertEquals(expectedSize, sketch.size());
+   }
+   
+   @Test
+   public void testSizeShortOverflowWithMaxShort() throws CMSMergeException {
+      double confidence = 0.999;
+      double epsilon = 0.0001;
+      int seed = 1;
+
+      ShortCountMinSketch sketch = new ShortCountMinSketch(epsilon, confidence, seed);
+
+      long freq1 = Long.MAX_VALUE;
+      short freq2 = 156;
+
+      sketch.add(1, freq1);
+      sketch.add(2, freq2);
+
+      ShortCountMinSketch newSketch = ShortCountMinSketch.merge(sketch, sketch);
+
+      short maxShortFromOverflow = Short.MAX_VALUE;
+      
+      long expectedSize = 2 * (maxShortFromOverflow + freq2);
+      assertEquals(expectedSize, newSketch.size());
+   }
+
+   @Test
+   public void testSizeCanStoreShort() throws CMSMergeException {
+      double confidence = 0.999;
+      double epsilon = 0.0001;
+      int seed = 1;
+
+      ShortCountMinSketch sketch = new ShortCountMinSketch(epsilon, confidence, seed);
+
+      short freq1 = Short.MAX_VALUE;
+      short freq2 = 156;
+
+      sketch.add(1, freq1);
+      sketch.add(2, freq2);
+
+      ShortCountMinSketch newSketch = ShortCountMinSketch.merge(sketch, sketch);
+
+      long expectedSize = 2 * (freq1 + freq2);
+      assertEquals(expectedSize, newSketch.size());
+   }
+
+   @Test
+   public void testAccuracy() {
+      int seed = Short.MAX_VALUE / 2;
+      Random r = new Random(seed);
+      int numItems = 10_000;
+      int[] xs = new int[numItems];
+      int maxScale = 20;
+      for (int i = 0; i < numItems; i++) {
+         int scale = r.nextInt(maxScale);
+         xs[i] = r.nextInt(1 << scale);
+      }
+
+      double epsOfTotalCount = 0.0001;
+      double confidence = 0.99;
+
+      ShortCountMinSketch sketch = new ShortCountMinSketch(epsOfTotalCount, confidence, seed);
+      for (int x : xs) {
+         sketch.add(x, (short) 1);
+      }
+
+      int[] actualFreq = new int[1 << maxScale];
+      for (int x : xs) {
+         actualFreq[x]++;
+      }
+
+      sketch = ShortCountMinSketch.deserialize(ShortCountMinSketch.serialize(sketch));
+
+      int numErrors = 0;
+      for (int i = 0; i < actualFreq.length; ++i) {
+         double ratio = ((double) (sketch.estimateCount(i) - actualFreq[i])) / numItems;
+         if (ratio > epsOfTotalCount) {
+            numErrors++;
+         }
+      }
+      double pCorrect = 1.0 - ((double) numErrors) / actualFreq.length;
+      assertTrue("Confidence not reached: required " + confidence + ", reached " + pCorrect, pCorrect > confidence);
+   }
+
+   @Test
+   public void testAccuracyStrings() {
+      int seed = 7364181;
+      int numItems = 1000000;
+      int absentItems = numItems * 10;
+      String[] xs = new String[numItems];
+      for (int i = 0; i < numItems; i++) {
+         xs[i] = UUID.randomUUID().toString();
+      }
+
+      double epsOfTotalCount = 0.0001;
+      double confidence = 0.99;
+
+      ShortCountMinSketch sketch = new ShortCountMinSketch(epsOfTotalCount, confidence, seed);
+      for (String x : xs) {
+         sketch.add(x, (short) 1);
+      }
+
+      Map<String, Long> actualFreq = new HashMap<String, Long>();
+      for (String x : xs) {
+         Long val = actualFreq.get(x);
+         if (val == null) {
+            actualFreq.put(x, 1L);
+         } else {
+            actualFreq.put(x, val + 1L);
+         }
+      }
+
+      sketch = ShortCountMinSketch.deserialize(ShortCountMinSketch.serialize(sketch));
+
+      int numErrors = 0;
+      for (Map.Entry<String, Long> entry : actualFreq.entrySet()) {
+         String key = entry.getKey();
+         long count = entry.getValue();
+         double ratio = ((double) (sketch.estimateCount(key) - count)) / numItems;
+         if (ratio > epsOfTotalCount) {
+            numErrors++;
+         }
+      }
+      for (int i = 0; i < absentItems; i++) {
+         String key = UUID.randomUUID().toString();
+         Long value = actualFreq.get(key);
+         long count = (value == null) ? 0L : value;
+         double ratio = ((double) (sketch.estimateCount(key) - count)) / numItems;
+         if (ratio > epsOfTotalCount) {
+            numErrors++;
+         }
+      }
+
+      double pCorrect = 1.0 - ((double) numErrors) / (numItems + absentItems);
+      System.out.println(pCorrect);
+      assertTrue("Confidence not reached: required " + confidence + ", reached " + pCorrect, pCorrect > confidence);
+
+      assertTrue("Confidence not reached: required " + confidence + ", reached " + pCorrect, pCorrect > confidence);
+   }
+
+
+   @Test
+   public void merge() throws CMSMergeException {
+      int numToMerge = 3;
+      int cardinality = 10_000;
+
+      double epsOfTotalCount = 0.0001;
+      double confidence = 0.99;
+      int seed = Short.MAX_VALUE / 2;
+
+      int maxScale = 20;
+      Random r = new Random();
+      TreeSet<Integer> vals = new TreeSet<Integer>();
+
+      ShortCountMinSketch baseline = new ShortCountMinSketch(epsOfTotalCount, confidence, seed);
+      ShortCountMinSketch[] sketchs = new ShortCountMinSketch[numToMerge];
+      for (int i = 0; i < numToMerge; i++) {
+         sketchs[i] = new ShortCountMinSketch(epsOfTotalCount, confidence, seed);
+         for (int j = 0; j < cardinality; j++) {
+            int scale = r.nextInt(maxScale);
+            int val = r.nextInt(1 << scale);
+            vals.add(val);
+            sketchs[i].add(val, (short) 1);
+            baseline.add(val, (short) 1);
+         }
+      }
+
+      ShortCountMinSketch merged = ShortCountMinSketch.merge(sketchs);
+
+      assertEquals(baseline.size(), merged.size());
+      assertEquals(baseline.getConfidence(), merged.getConfidence(), baseline.getConfidence() / 100);
+      assertEquals(baseline.getRelativeError(), merged.getRelativeError(), baseline.getRelativeError() / 100);
+      for (int val : vals) {
+         assertEquals(baseline.estimateCount(val), merged.estimateCount(val));
+      }
+   }
+
+   @Test
+   public void testMergeEmpty() throws CMSMergeException {
+      assertNull(ShortCountMinSketch.merge());
+   }
+
+   @Test(expected = CMSMergeException.class)
+   public void testUncompatibleMerge() throws CMSMergeException {
+      ShortCountMinSketch cms1 = new ShortCountMinSketch(1, 1, 0);
+      ShortCountMinSketch cms2 = new ShortCountMinSketch(0.1, 0.1, 0);
+      ShortCountMinSketch.merge(cms1, cms2);
+   }
+
+   private static void checkCountMinSketchSerialization(ShortCountMinSketch cms)
+         throws IOException, ClassNotFoundException {
+      byte[] bytes = ShortCountMinSketch.serialize(cms);
+      ShortCountMinSketch serializedCms = (ShortCountMinSketch) ShortCountMinSketch.deserialize(bytes);
+
+      assertEquals(cms, serializedCms);
+   }
+
+   @Test
+   public void testSerializationForDepthCms() throws IOException, ClassNotFoundException {
+      checkCountMinSketchSerialization(new ShortCountMinSketch(12, 2045, 1));
+   }
+
+   @Test
+   @Ignore("depends on the os. But works.")
+   public void testSerializationForConfidenceCms() throws IOException, ClassNotFoundException {
+      checkCountMinSketchSerialization(new ShortCountMinSketch(0.0001, 0.99999999999, 1));
+   }
+
+   @Test
+   public void testEquals() {
+      double eps1 = 0.0001;
+      double eps2 = 0.000001;
+      double confidence = 0.99;
+      int seed = 1;
+
+      final ShortCountMinSketch sketch1 = new ShortCountMinSketch(eps1, confidence, seed);
+      assertEquals(sketch1, sketch1);
+
+      final ShortCountMinSketch sketch2 = new ShortCountMinSketch(eps1, confidence, seed);
+      assertEquals(sketch1, sketch2);
+
+      final CountMinSketch sketch3 = new ConservativeAddSketch(eps1, confidence, seed);
+      assertNotEquals(sketch1, sketch3);
+
+      assertNotEquals(sketch1, null);
+
+      sketch1.add(1, (short) 123);
+      sketch2.add(1, (short) 123);
+      assertEquals(sketch1, sketch2);
+
+      sketch1.add(1, (short) 4);
+      assertNotEquals(sketch1, sketch2);
+
+      final ShortCountMinSketch sketch4 = new ShortCountMinSketch(eps1, confidence, seed);
+      final ShortCountMinSketch sketch5 = new ShortCountMinSketch(eps2, confidence, seed);
+      assertNotEquals(sketch4, sketch5);
+
+      sketch3.add(1, (short) 7);
+      sketch4.add(1, (short) 7);
+      assertNotEquals(sketch4, sketch5);
+   }
+
+   @Test
+   public void testToString() {
+      double eps = 0.0001;
+      double confidence = 0.99;
+      int seed = 1;
+
+      final ShortCountMinSketch sketch = new ShortCountMinSketch(eps, confidence, seed);
+      assertEquals("ShortCountMinSketch{" +
+            "eps=" + eps +
+            ", confidence=" + confidence +
+            ", depth=" + 7 +
+            ", width=" + 20000 +
+            ", size=" + 0 +
+            '}', sketch.toString());
+
+      sketch.add(12, (short) 145);
+      assertEquals("ShortCountMinSketch{" +
+            "eps=" + eps +
+            ", confidence=" + confidence +
+            ", depth=" + 7 +
+            ", width=" + 20000 +
+            ", size=" + 145 +
+            '}', sketch.toString());
+   }
+}

--- a/src/test/java/com/clearspring/analytics/stream/frequency/ShortCountMinSketchTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/frequency/ShortCountMinSketchTest.java
@@ -12,9 +12,9 @@ import java.util.Random;
 import java.util.TreeSet;
 import java.util.UUID;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
+import com.clearspring.analytics.TestUtils;
 import com.clearspring.analytics.stream.frequency.ShortCountMinSketch.CMSMergeException;
 
 public class ShortCountMinSketchTest {
@@ -234,8 +234,8 @@ public class ShortCountMinSketchTest {
 
    private static void checkCountMinSketchSerialization(ShortCountMinSketch cms)
          throws IOException, ClassNotFoundException {
-      byte[] bytes = ShortCountMinSketch.serialize(cms);
-      ShortCountMinSketch serializedCms = (ShortCountMinSketch) ShortCountMinSketch.deserialize(bytes);
+      byte[] bytes = TestUtils.serialize(cms);
+      ShortCountMinSketch serializedCms = (ShortCountMinSketch) TestUtils.deserialize(bytes);
 
       assertEquals(cms, serializedCms);
    }
@@ -246,9 +246,8 @@ public class ShortCountMinSketchTest {
    }
 
    @Test
-   @Ignore("depends on the os. But works.")
    public void testSerializationForConfidenceCms() throws IOException, ClassNotFoundException {
-      checkCountMinSketchSerialization(new ShortCountMinSketch(0.0001, 0.99999999999, 1));
+      checkCountMinSketchSerialization(new ShortCountMinSketch(0.0001, 0.999999999992724, 1));
    }
 
    @Test


### PR DESCRIPTION
We have to store a lot CountMinSketches in heap and we don't need the `long` values in there. Therefore we created a new one that just uses `short` values. It's already used in production.