### PR TITLE
Test: Specify hash64

### DIFF
--- a/src/test/java/com/clearspring/analytics/hash/TestMurmurHash.java
+++ b/src/test/java/com/clearspring/analytics/hash/TestMurmurHash.java
@@ -44,7 +44,7 @@ public class TestMurmurHash {
         String input = "hashthis";
         byte[] inputBytes = input.getBytes();
 
-        long hashOfString = MurmurHash.hash64(input);
+        long hashOfString = -8896273065425798843L;
         assertEquals("MurmurHash.hash64(byte[]) did not match MurmurHash.hash64(String)",
                      hashOfString, MurmurHash.hash64(inputBytes));
 


### PR DESCRIPTION
The proposed change specifies what the good hash code must be.
With the current test, any change in "hash" would still make the test pass, incl. the changes that would result in an inefficient hash.