### PR TITLE
Add intersect method to bloom filter

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/membership/BloomFilter.java
+++ b/src/main/java/com/clearspring/analytics/stream/membership/BloomFilter.java
@@ -153,7 +153,7 @@ public class BloomFilter extends Filter {
         BitSet intersection = (BitSet) this.filter().clone();
         BloomFilter intersectionBloomFilter = new BloomFilter(this.getHashCount(), intersection);
         for (Filter otherFilter : filters) {
-            if (!(otherFilter instanceof BloomFilter || this.hashCount != otherFilter.hashCount)) {
+            if (!(otherFilter instanceof BloomFilter) || this.hashCount != otherFilter.hashCount) {
                 throw new IllegalArgumentException(("Cannot merge filters of different class or size"));
             }
             intersection.and(((BloomFilter) otherFilter).filter());

--- a/src/main/java/com/clearspring/analytics/stream/membership/BloomFilter.java
+++ b/src/main/java/com/clearspring/analytics/stream/membership/BloomFilter.java
@@ -145,6 +145,23 @@ public class BloomFilter extends Filter {
     }
 
     /**
+     * Intersect a Bloom Filter with a number of other bloom filters.
+     * @param filters
+     * @return a new Bloom Filter that has each filter bit set if and only if all the input bloom filters had that bit set
+     */
+    public Filter intersect(Filter... filters) {
+        BitSet intersection = (BitSet) this.filter().clone();
+        BloomFilter intersectionBloomFilter = new BloomFilter(this.getHashCount(), intersection);
+        for (Filter otherFilter : filters) {
+            if (!(otherFilter instanceof BloomFilter || this.hashCount != otherFilter.hashCount)) {
+                throw new IllegalArgumentException(("Cannot merge filters of different class or size"));
+            }
+            intersection.and(((BloomFilter) otherFilter).filter());
+        }
+        return intersectionBloomFilter;
+    }
+
+    /**
      * @return a BloomFilter that always returns a positive match, for testing
      */
     public static BloomFilter alwaysMatchingBloomFilter() {

--- a/src/test/java/com/clearspring/analytics/stream/membership/BloomFilterTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/membership/BloomFilterTest.java
@@ -55,6 +55,7 @@ public class BloomFilterTest {
     @Before
     public void clear() {
         bf.clear();
+        bf2.clear();
     }
 
     @Test

--- a/src/test/java/com/clearspring/analytics/stream/membership/BloomFilterTest.java
+++ b/src/test/java/com/clearspring/analytics/stream/membership/BloomFilterTest.java
@@ -76,6 +76,18 @@ public class BloomFilterTest {
         assertTrue(mergeBf.isPresent("c"));
     }
 
+    @Test
+    public void testIntersect() {
+        bf.add("a");
+        bf.add("b");
+        bf2.add("a");
+        bf2.add("c");
+        BloomFilter intersectionBf = (BloomFilter) bf.intersect(bf2);
+        assertTrue(intersectionBf.isPresent("a"));
+        assertFalse(intersectionBf.isPresent("b"));
+        assertFalse(intersectionBf.isPresent("c"));
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void testMergeException() {
         BloomFilter bf3 = new BloomFilter(ELEMENTS*10, 1);


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Bloom_filter#Interesting_properties , it is valid to construct a new bloom filter from a set of constituent bloom filters by applying an 'AND' operation to the constituent bits sets.

"... The intersect operation satisfies a weaker property: the false positive probability in the resulting Bloom filter is at most the false-positive probability in one of the constituent Bloom filters, but may be larger than the false positive probability in the Bloom filter created from scratch using the intersection of the two sets."

This PR adds a method to support this operation, and a unit test to verify.