### PR TITLE
Close/flush the OutputStream before calling `toByteArray()` on underlying `ByteArrayOutputStream`

### DIFF
--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java
@@ -195,6 +195,7 @@ public class HyperLogLog implements ICardinality, Serializable {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutput dos = new DataOutputStream(baos);
         writeBytes(dos);
+        baos.close();
 
         return baos.toByteArray();
     }

--- a/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
+++ b/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java
@@ -740,6 +740,7 @@ public class HyperLogLogPlus implements ICardinality, Serializable {
                 }
                 break;
         }
+        dos.close();
 
         return baos.toByteArray();
     }

--- a/src/main/java/com/clearspring/analytics/stream/frequency/CountMinSketch.java
+++ b/src/main/java/com/clearspring/analytics/stream/frequency/CountMinSketch.java
@@ -308,6 +308,7 @@ public class CountMinSketch implements IFrequency, Serializable {
                     s.writeLong(sketch.table[i][j]);
                 }
             }
+            s.close();
             return bos.toByteArray();
         } catch (IOException e) {
             // Shouldn't happen

--- a/src/main/java/com/clearspring/analytics/stream/quantile/QDigest.java
+++ b/src/main/java/com/clearspring/analytics/stream/quantile/QDigest.java
@@ -332,6 +332,7 @@ public class QDigest implements IQuantileEstimator {
                 s.writeLong(k);
                 s.writeLong(d.node2count.get(k));
             }
+            s.close();
             return bos.toByteArray();
         } catch (IOException e) {
             // Should never happen

--- a/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
+++ b/src/test/java/com/clearspring/analytics/stream/cardinality/TestHyperLogLogPlus.java
@@ -402,6 +402,7 @@ public class TestHyperLogLogPlus {
             dos.writeInt(x);
         }
 
+        dos.close();
         byte[] legacyBytes = baos.toByteArray();
 
         // decode legacy
@@ -443,6 +444,7 @@ public class TestHyperLogLogPlus {
             dos.write(bytes);
         }
         dos.writeInt(-1);
+        dos.close();
 
         byte[] legacyBytes = baos.toByteArray();
 


### PR DESCRIPTION
When an `OutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `OutputStream` before invoking the underlying instances' `toByteArray()`. Although in some of these case it is not strictly necessary because the `writeObject` method is invoked right before `toByteArray`, and `writeObject` internally calls `flush`/`drain`. However, it is good practice to call `flush`/`close` explicitly as mentioned [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).

This pull request adds a call to `close()` or `flush()` before calls to `toByteArray()`.
